### PR TITLE
Better tests

### DIFF
--- a/scrapy_proj/grab_html.py
+++ b/scrapy_proj/grab_html.py
@@ -1,0 +1,72 @@
+import argparse
+import os
+import errno
+import lxml
+import lxml.html
+
+script_dir = os.path.dirname(os.path.realpath(__file__))
+
+
+#http://stackoverflow.com/a/5032238
+#Recursively try to create a path.  Raise an exception if it fails due to any
+#reason other than the directory already existing
+def make_sure_path_exists(path):
+    try:
+        os.makedirs(path)
+    except OSError as exception:
+        if exception.errno != errno.EEXIST:
+            raise
+        if not os.path.isdir(path):
+            raise
+
+
+def grab_html(args):
+    htmldir = os.path.join(script_dir, 'tests', 'html_data', args.name)
+    make_sure_path_exists(htmldir)
+    t = lxml.html.parse(args.url)
+    title = t.find(".//title").text
+
+    with open(os.path.join(htmldir, title + '.html'), 'w') as f:
+        f.write(lxml.etree.tostring(t, pretty_print=True))
+    # print response.content
+
+    # parsed_url = parse_url(args.start_url)
+
+    # domain = parsed_url.netloc
+    # name = args.name.lower()
+
+    # values = {
+    #     'crawler_name': name.capitalize(),
+    #     'source': name,
+    #     'name': domain,
+    #     'domain': domain,
+    #     'start_url': args.start_url,
+    # }
+
+    # spider_filename = os.path.join(script_dir, 'openrecipes', 'spiders', '%s_spider.py' % name)
+    # with open(spider_filename, 'w') as f:
+    #     f.write(SpiderTemplate % values)
+
+    # if args.with_feed:
+    #     feed_url = args.with_feed[0]
+    #     feed_domain = parse_url(feed_url).netloc
+    #     values['feed_url'] = feed_url
+    #     values['name'] = name
+    #     if feed_domain == domain:
+    #         values['feed_domains'] = domain
+    #     else:
+    #         values['feed_domains'] = '%s",\n        "%s' % (domain, feed_domain)
+    #     feed_filename = os.path.join(script_dir, 'openrecipes', 'spiders', '%s_feedspider.py' % name)
+    #     with open(feed_filename, 'w') as f:
+    #         f.write(FeedSpiderTemplate % values)
+
+
+epilog = """
+Example usage: python grab_html.py cookincanuck http://www.cookincanuck.com/2013/04/10-minute-thai-shrimp-cucumber-avocado-salad-recipe/
+"""
+parser = argparse.ArgumentParser(description='Grab page html for testing', epilog=epilog)
+parser.add_argument('name', help='Spider name')
+parser.add_argument('url', help='URL of recipe page')
+
+args = parser.parse_args()
+grab_html(args)

--- a/scrapy_proj/openrecipes/items.py
+++ b/scrapy_proj/openrecipes/items.py
@@ -25,7 +25,7 @@ class RecipeItemLoader(ItemLoader):
 
     cookingMethod_out = Compose(TakeFirst(), trim_whitespace)
     cookTime_out = Compose(TakeFirst(), strip_html, get_isoduration)
-    ingredients_out = Compose(MapCompose(trim_whitespace, filter_ingredients), Join("\n"), strip_html)
+    ingredients_out = Compose(MapCompose(strip_html, trim_whitespace, filter_ingredients), Join("\n"))
     prepTime_out = Compose(TakeFirst(), strip_html, get_isoduration)
     recipeCategory_out = Compose(TakeFirst(), trim_whitespace)
     recipeCuisine_out = Compose(TakeFirst(), trim_whitespace)

--- a/scrapy_proj/openrecipes/items.py
+++ b/scrapy_proj/openrecipes/items.py
@@ -5,8 +5,7 @@ from openrecipes.util import strip_html, trim_whitespace, get_isodate, get_isodu
 
 
 def filter_ingredients(x):
-    return x
-    # return None if 'ingredient' in x.lower() else x
+    return None if 'ingredient' in x.lower() else x
 
 
 class RecipeItemLoader(ItemLoader):

--- a/scrapy_proj/openrecipes/spiders/cookincanuck_spider.py
+++ b/scrapy_proj/openrecipes/spiders/cookincanuck_spider.py
@@ -47,9 +47,8 @@ class CookincanuckMixin(object):
             ingredient_scopes = r_scope.select(ingredients_path)
             ingredients = []
             for i_scope in ingredient_scopes:
-                ind = i_scope.extract()
-                ind = ind.strip()
-                ingredients.append("%s " % (ind))
+                ind = i_scope.select('.//text()').extract()
+                ingredients.append(''.join(ind).strip())
             il.add_value('ingredients', ingredients)
 
             il.add_value('datePublished', r_scope.select(datePublished).extract())

--- a/scrapy_proj/tests/html_data/cookincanuck/Cookin Canuck – 10-Minute Thai Shrimp, Cucumber & Avocado Salad Recipe.html
+++ b/scrapy_proj/tests/html_data/cookincanuck/Cookin Canuck – 10-Minute Thai Shrimp, Cucumber & Avocado Salad Recipe.html
@@ -1,0 +1,716 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml" xmlns="http://www.w3.org/1999/xhtml" dir="ltr" lang="en-US" xml:lang="en-US">
+  <head profile="http://gmpg.org/xfn/11">
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
+    <title>Cookin Canuck &#8211; 10-Minute Thai Shrimp, Cucumber &amp; Avocado Salad Recipe</title>
+    <meta name="robots" content="noodp, noydir" />
+    <meta name="description" content="This Thai-inspired shrimp, cucumber and avocado salad is not only tasty and satisfying, but it only takes 10 minutes to make." />
+    <meta name="keywords" content="recipe, salad, Thai, cucumber, shrimp, avocado, seafood, healthy, low fat, low calorie" />
+    <link rel="stylesheet" href="http://www.cookincanuck.com/wp-content/themes/thesis_18/style.css?021611-151312" type="text/css" media="screen, projection" />
+    <link rel="stylesheet" href="http://www.cookincanuck.com/wp-content/themes/thesis_18/custom/layout.css?040513-215049" type="text/css" media="screen, projection" />
+<!--[if lte IE 8]><link rel="stylesheet" href="http://www.cookincanuck.com/wp-content/themes/thesis_18/lib/css/ie.css?021611-151325" type="text/css" media="screen, projection" /><![endif]-->
+    <link rel="stylesheet" href="http://www.cookincanuck.com/wp-content/themes/thesis_18/custom/custom.css?011213-143027" type="text/css" media="screen, projection" />
+    <link rel="shortcut icon" href="http://66.147.244.219/~cookinca/wp-content/uploads/2011/03/cc_favicon2.png" />
+    <link rel="canonical" href="http://www.cookincanuck.com/2013/04/10-minute-thai-shrimp-cucumber-avocado-salad-recipe/" />
+    <link rel="alternate" type="application/rss+xml" title="Cookin Canuck RSS Feed" href="http://feeds.feedburner.com/blogspot/hIdj" />
+    <link rel="pingback" href="http://www.cookincanuck.com/xmlrpc.php" />
+    <link rel="EditURI" type="application/rsd+xml" title="RSD" href="http://www.cookincanuck.com/xmlrpc.php?rsd" />
+    <link rel="alternate" type="application/rss+xml" title="Cookin Canuck &#187; 10-Minute Thai Shrimp, Cucumber &amp; Avocado Salad Recipe Comments Feed" href="http://www.cookincanuck.com/2013/04/10-minute-thai-shrimp-cucumber-avocado-salad-recipe/feed/" />
+    <link rel="stylesheet" id="pinterest-pin-it-button-css" href="http://www.cookincanuck.com/wp-content/plugins/pinterest-pin-it-button/css/pinterest-pin-it-button.css?ver=3.3.2" type="text/css" media="all" />
+    <script type="text/javascript" src="http://www.cookincanuck.com/wp-includes/js/comment-reply.js?ver=20090102"></script>
+    <script type="text/javascript" src="http://www.cookincanuck.com/wp-includes/js/jquery/jquery.js?ver=1.7.1"></script>
+    <script type="text/javascript">
+/* &lt;![CDATA[ */
+var SHRSB_Globals = {"src":"http:\/\/www.cookincanuck.com\/wp-content\/uploads\/shareaholic\/spritegen","perfoption":"1","twitter_template":"%24%7Btitle%7D+-+%24%7Bshort_link%7D+via+%40cookincanuck","locale":"0","shortener":"google","shortener_key":"","pubGaSocial":"0","pubGaKey":""};
+/* ]]&gt; */
+</script>
+    <script type="text/javascript" src="http://dtym7iokkjlif.cloudfront.net/media/js/jquery.shareaholic-publishers-sb.min.js?ver=6.1.2.0"></script>
+    <style type="text/css">
+.pib-sharebar li { width: 100px; }
+
+</style>
+<!-- Shareaholic Content Tags -->
+    <meta property="shareaholic:site_name" content="Cookin Canuck" />
+    <meta property="shareaholic:image" content="http://www.cookincanuck.com/wp-content/uploads/2013/04/Thai-Shrimp-Cucumber.jpg" />
+<!-- / Shareaholic Content Tags -->
+<!-- Shareaholic - Open Graph Tags -->
+    <meta property="og:image" content="http://www.cookincanuck.com/wp-content/uploads/2013/04/Thai-Shrimp-Cucumber-300x300.jpg" />
+<!-- / Shareaholic - Open Graph Tags -->
+    <script type="text/javascript" src="http://www.cookincanuck.com/wp-content/plugins/ziplist-recipe-plugin/zlrecipe_print.js"></script>
+    <script type="text/javascript" src="http://www.zlcdn.com/javascripts/pt_include.js"></script>
+    <link charset="utf-8" href="http://www.zlcdn.com/stylesheets/minibox/generic.css" rel="stylesheet" type="text/css" />
+<!-- Wordpress Popular Posts v2.3.2 -->
+    <script type="text/javascript">&#13;
+    /* &lt;![CDATA[ */				&#13;
+	jQuery.post('http://www.cookincanuck.com/wp-admin/admin-ajax.php', {action: 'wpp_update', token: 'ddc597cfd3', id: 9722}, function(data){/*alert(data);*/});&#13;
+    /* ]]&gt; */&#13;
+</script>
+<!-- End Wordpress Popular Posts v2.3.2 -->
+  </head>
+  <body class="custom">
+<div id="container">
+<div id="page">
+	<div id="header">
+		<p id="logo"><a href="http://www.cookincanuck.com">Cookin Canuck</a></p>
+	</div>
+<div class="menu-custom-menu-container"><ul id="menu-custom-menu" class="menu"><li id="menu-item-1488" class="menu-item menu-item-type-custom menu-item-object-custom menu-item-home menu-item-1488"><a href="http://www.cookincanuck.com">Home</a></li>
+<li id="menu-item-1486" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-1486"><a href="http://www.cookincanuck.com/about/">About</a></li>
+<li id="menu-item-1484" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-1484"><a href="http://www.cookincanuck.com/recipes/">Recipes</a>
+<ul class="sub-menu"><li id="menu-item-5472" class="menu-item menu-item-type-custom menu-item-object-custom menu-item-5472"><a href="http://www.cookincanuck.com/recipes/">By Category</a></li>
+</ul></li>
+<li id="menu-item-5468" class="menu-item menu-item-type-custom menu-item-object-custom menu-item-5468"><a href="http://cookincanuck.ziplist.com/recipes/box">Recipe Box</a>
+<ul class="sub-menu"><li id="menu-item-8452" class="menu-item menu-item-type-custom menu-item-object-custom menu-item-8452"><a href="http://cookincanuck.ziplist.com/recipes/meal_planner">Menu Planner</a></li>
+	<li id="menu-item-5467" class="menu-item menu-item-type-custom menu-item-object-custom menu-item-5467"><a href="http://cookincanuck.ziplist.com/mylist">Shopping List</a></li>
+</ul></li>
+<li id="menu-item-9682" class="menu-item menu-item-type-custom menu-item-object-custom menu-item-9682"><a href="http://astore.amazon.com/coocan0f-20">Store</a></li>
+<li id="menu-item-1487" class="menu-item menu-item-type-taxonomy menu-item-object-category menu-item-1487"><a href="http://www.cookincanuck.com/category/how-to/">How-to</a></li>
+<li id="menu-item-4898" class="menu-item menu-item-type-taxonomy menu-item-object-category menu-item-4898"><a href="http://www.cookincanuck.com/category/healthy-2/">Healthy Living</a></li>
+<li id="menu-item-1483" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-1483"><a href="http://www.cookincanuck.com/frequently-asked-questions/">FAQ</a></li>
+<li id="menu-item-1482" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-1482"><a href="http://www.cookincanuck.com/press/">Press</a></li>
+<li id="menu-item-1485" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-1485"><a href="http://www.cookincanuck.com/contact/">Contact</a></li>
+</ul></div>
+	<div id="content_box">
+		<div id="content" class="hfeed">
+
+<div class="time_stamp">&#13;
+<div class="time_stamp_month">Apr <span class="time_stamp_day&quot;">11</span></div>&#13;
+<div class="time_stamp_year">2013</div>&#13;
+</div>&#13;
+			<div class="post-9722 post type-post status-publish format-standard hentry category-entrees category-salads category-seafood-recipes tag-avocado tag-cucumber tag-healthy tag-low-calorie tag-low-fat tag-recipe tag-salad tag-seafood tag-shrimp tag-thai post_box top" id="post-9722">
+				<div class="headline_area">
+					<h1 class="entry-title">10-Minute Thai Shrimp, Cucumber &amp; Avocado Salad Recipe</h1>
+				</div>
+				<div class="format_text entry-content">
+<!-- Start Shareaholic LikeButtonSetTop Automatic --><div style="clear: both; min-height: 1px; height: 3px; width: 100%;"></div><div class="shareaholic-like-buttonset" style="float:none;height:30px;"><a class="shareaholic-fblike" data-shr_layout="button_count" data-shr_showfaces="false" data-shr_href="http%3A%2F%2Fwww.cookincanuck.com%2F2013%2F04%2F10-minute-thai-shrimp-cucumber-avocado-salad-recipe%2F" data-shr_title="10-Minute+Thai+Shrimp%2C+Cucumber+%26+Avocado+Salad+Recipe+"></a><a class="shareaholic-tweetbutton" data-shr_count="horizontal" data-shr_href="http%3A%2F%2Fwww.cookincanuck.com%2F2013%2F04%2F10-minute-thai-shrimp-cucumber-avocado-salad-recipe%2F" data-shr_title="10-Minute+Thai+Shrimp%2C+Cucumber+%26+Avocado+Salad+Recipe+"></a><a class="shareaholic-googleplusone" data-shr_size="medium" data-shr_count="true" data-shr_href="http%3A%2F%2Fwww.cookincanuck.com%2F2013%2F04%2F10-minute-thai-shrimp-cucumber-avocado-salad-recipe%2F" data-shr_title="10-Minute+Thai+Shrimp%2C+Cucumber+%26+Avocado+Salad+Recipe+"></a></div><div style="clear: both; min-height: 1px; height: 3px; width: 100%;"></div><!-- End Shareaholic LikeButtonSetTop Automatic --><div class="pin-it-btn-wrapper"><table class="pib-count-table pib-count-table-horizontal"><tbody><tr><td><a href="http://pinterest.com/pin/create/button/?url=http%3A%2F%2Fwww.cookincanuck.com%2F2013%2F04%2F10-minute-thai-shrimp-cucumber-avocado-salad-recipe%2F&amp;media=http%3A%2F%2Ffarm9.staticflickr.com%2F8255%2F8636959668_73ab6460b3_c.jpg&amp;description=10-Minute%20Thai%20Shrimp%2C%20Cucumber%20%26%23038%3B%20Avocado%20Salad%20Recipe" count-layout="horizontal" class="pin-it-button-no-iframe pin-it-button-user-selects-image" rel="nobox"><img border="0" class="pib-count-img" src="//assets.pinterest.com/images/PinExt.png" title="Pin It" /></a></td>
+<td class="pib-count-cell"><div class="pib-count-bubble"></div></td>
+</tr></tbody></table></div><p><a title="10-Minute Thai Shrimp, Cucumber &amp; Avocado Salad Recipe #recipe #healthy by CookinCanuck, on Flickr" href="http://www.flickr.com/photos/cookincanuck/8636959668/"><img src="http://farm9.staticflickr.com/8255/8636959668_73ab6460b3_c.jpg" alt="10-Minute Thai Shrimp, Cucumber &amp; Avocado Salad Recipe #recipe #healthy" width="534" height="800" /></a></p>
+<p>&#8220;Quick lunch&#8221; does not have to mean &#8220;boring lunch&#8221;. Believe me, I&#8217;ve had my fair share of lackluster sandwiches or past-their-prime leftovers, but leaving the table dissatisfied leads to trouble. Snacking kind of trouble. And I don&#8217;t mean the <a href="http://www.cookincanuck.com/tag/snack/">good kind of snacking</a>. A couple of cheese and crackers here, a handful of chips there. Before you know it, you&#8217;re digging through the pantry for any tiny morsel of chocolate that you can find. An almost-empty bag of chocolate chips? Score!</p>
+<p>The only way that I can head off this inevitable downward spiral is by eating a lunch that actually satisfies me. Something with flavor and a good dose of protein.<br /><span id="more-9722"></span><br />
+This Thai-inspired shrimp, cucumber and avocado salad meets both of those criteria. And it truly only took ten minutes to make. While you&#8217;re waiting for the water to boil for the shrimp, slice the cucumber and avocado, and quickly whisk together the simple dressing. The shrimp cook for only one minute (any longer and they&#8217;ll be little rubber specimens), and are ready to add to the vegetables and dressing as soon as you scoop them out of the ice water bath.</p>
+<p>Quick, easy and tasty.</p>
+<p>Snacking crisis averted.</p>
+<h2>The recipe:</h2>
+<h4>The dressing:</h4>
+<p>In a small bowl, whisk together the rice vinegar, fish sauce, agave nectar and chili garlic sauce.</p>
+<p><a title="10-Minute Thai Shrimp, Cucumber &amp; Avocado Salad Recipe #recipe #healthy by CookinCanuck, on Flickr" href="http://www.flickr.com/photos/cookincanuck/8636948110/"><img src="http://farm9.staticflickr.com/8532/8636948110_18a7232e4e.jpg" alt="10-Minute Thai Shrimp, Cucumber &amp; Avocado Salad Recipe #recipe #healthy" width="500" height="464" /></a></p>
+<h4>The salad:</h4>
+<p>Prepare a bowl of ice water.</p>
+<p>Set a large saucepan of water over high heat, and bring the water to a boil. Add the shrimp and boil until the shrimp is just cooked through, 60 to 75 seconds. Drain and immediately plunge the shrimp into the ice water to stop them from cooking further. Drain.</p>
+<p><a title="10-Minute Thai Shrimp, Cucumber &amp; Avocado Salad Recipe #recipe #healthy by CookinCanuck, on Flickr" href="http://www.flickr.com/photos/cookincanuck/8636959464/"><img src="http://farm9.staticflickr.com/8260/8636959464_b33996b32c_c.jpg" alt="10-Minute Thai Shrimp, Cucumber &amp; Avocado Salad Recipe #recipe #healthy" width="534" height="800" /></a></p>
+<p>In a medium bowl, mix together the shrimp, cucumber, avocado and cilantro.</p>
+<p><a title="10-Minute Thai Shrimp, Cucumber &amp; Avocado Salad Recipe #recipe #healthy by CookinCanuck, on Flickr" href="http://www.flickr.com/photos/cookincanuck/8636959674/"><img src="http://farm9.staticflickr.com/8260/8636959674_861f78c5db_c.jpg" alt="10-Minute Thai Shrimp, Cucumber &amp; Avocado Salad Recipe #recipe #healthy" width="534" height="800" /></a></p>
+<p>Pour in the dressing and toss to combine. Serve.</p>
+<h2>More shrimp recipes:</h2>
+<p><a title="Shrimp Recipe by Cookin' Canuck by CookinCanuck, on Flickr" href="http://www.flickr.com/photos/cookincanuck/8636947826/"><img src="http://farm9.staticflickr.com/8534/8636947826_7514106386.jpg" alt="Shrimp Recipe by Cookin' Canuck" width="500" height="464" /></a><br />
+Cookin&#8217; Canuck&#8217;s <a href="tp://www.cookincanuck.com/2012/10/fishermans-soup-recipe-with-tilapia-shrimp-tomatoes-capers/">Fisherman&#8217;s Soup Recipe with Tilapia, Shrimp, Tomatoes &amp; Capers</a><br />
+Cookin&#8217; Canuck&#8217;s <a href="http://www.cookincanuck.com/2012/03/salad-cups-with-quinoa-shrimp-avocado-lemon-dressing-recipe/">Salad Cups with Quinoa, Shrimp, Avocado &amp; Lemon Dressing Recipe</a><br />
+Gimme Some Oven&#8217;s <a href="http://www.gimmesomeoven.com/chipotle-lime-shrimp/" target="_blank">Chipotle Lime Shrimp</a><br />
+Garlic My Soul&#8217;s <a href="http://garlicmysoul.com/blog/paleo-pesto-with-shrimp-and-zucchini/" target="_blank">Paleo Pesto with Shrimp &amp; Zucchini</a><br />
+Clookbook&#8217;s <a href="http://clookbook.com/2011/09/03/shrimp-pad-thai/" target="_blank">Shrimp Pad Thai</a></p>
+<p>&#13;
+    </p><div id="zlrecipe-container-210" class="zlrecipe-container-border">&#13;
+    <div id="zlrecipe-container" class="serif" itemscope="" itemtype="http://schema.org/Recipe">&#13;
+      <div id="zlrecipe-innerdiv">&#13;
+        <div class="item b-b"><div class="zlrecipe-print-link fl-r"><a class="butn-link" title="Print this recipe" href="javascript:void(0);" onclick="zlrPrint('zlrecipe-container-210'); return false"></a></div><div id="zl-recipe-link-210" class="zl-recipe-link fl-r">&#13;
+		  <a class="butn-link" title="Add this recipe to your ZipList, where you can store all of your favorite web recipes in one place and easily add ingredients to your shopping list." onmouseup="getZRecipeArgs(this, {'partner_key':'cookincanuck', 'url':'http://www.cookincanuck.com/2013/04/10-minute-thai-shrimp-cucumber-avocado-salad-recipe/', 'class':'hrecipe'}); return false;" href="javascript:void(0);"></a>&#13;
+		</div><div id="zlrecipe-title" itemprop="name" class="b-b h-1 strong">10-Minute Thai Shrimp, Cucumber &amp; Avocado Salad Recipe</div>&#13;
+      </div><div class="zlmeta zlclear">&#13;
+      <div class="fl-l width-50"></div>&#13;
+      <div class="fl-l width-50"><p id="zlrecipe-yield">Yield: <span itemprop="recipeYield">Serves 2</span></p><div id="zlrecipe-nutrition" itemprop="nutrition" itemscope="" itemtype="http://schema.org/NutritionInformation"><p id="zlrecipe-serving-size">Serving Size: <span itemprop="servingSize">1 1/4 cups (approximately)</span></p><p id="zlrecipe-calories">Calories per serving: <span itemprop="calories">201.2 cal</span></p><p id="zlrecipe-fat">Fat per serving: <span itemprop="fatContent">Total 5.4g / Saturated Fat 0.9g</span></p></div></div>&#13;
+      <div class="zlclear">&#13;
+      </div>&#13;
+    </div><div class="img-desc-wrap"><p class="t-a-c hide-card hide-print">&#13;
+			  <img class="photo" itemprop="image" src="http://www.cookincanuck.com/wp-content/uploads/2013/04/Thai-Shrimp-Cucumber.jpg" title="10-Minute Thai Shrimp, Cucumber &amp; Avocado Salad Recipe" alt="10-Minute Thai Shrimp, Cucumber &amp; Avocado Salad Recipe" /></p><div id="zlrecipe-summary" itemprop="description"><p class="summary italic">From the kitchen of Cookin' Canuck.  www.cookincanuck.com</p></div></div><p id="zlrecipe-ingredients" class="h-4 strong">Ingredients</p><ul id="zlrecipe-ingredients-list"><div id="zlrecipe-ingredient-0" class="ingredient-label">The dressing:&#13;</div><li id="zlrecipe-ingredient-1" class="ingredient" itemprop="ingredients">1 1/2 tbsp rice vinegar&#13;</li><li id="zlrecipe-ingredient-2" class="ingredient" itemprop="ingredients">1 tbsp fish sauce&#13;</li><li id="zlrecipe-ingredient-3" class="ingredient" itemprop="ingredients">2 tsp agave nectar&#13;</li><li id="zlrecipe-ingredient-4" class="ingredient" itemprop="ingredients">1/2 tsp chili garlic sauce&#13;</li><div id="zlrecipe-ingredient-5" class="ingredient-label">The salad:&#13;</div><li id="zlrecipe-ingredient-6" class="ingredient" itemprop="ingredients">1/2 lb shrimp, shelled &amp; deveined&#13;</li><li id="zlrecipe-ingredient-7" class="ingredient" itemprop="ingredients">1/2 English cucumber, cut in half lengthwise &amp; thinly sliced&#13;</li><li id="zlrecipe-ingredient-8" class="ingredient" itemprop="ingredients">1/4 avocado, diced&#13;</li><li id="zlrecipe-ingredient-9" class="ingredient" itemprop="ingredients">2 tbsp minced cilantro</li></ul><p id="zlrecipe-instructions" class="h-4 strong">Instructions</p><ol id="zlrecipe-instructions-list" class="instructions"><div id="zlrecipe-instruction-0" class="instruction-label">The dressing:&#13;</div><li id="zlrecipe-instruction-1" class="instruction" itemprop="recipeInstructions">In a small bowl, whisk together the rice vinegar, fish sauce, agave nectar and chili garlic sauce.&#13;</li><div id="zlrecipe-instruction-2" class="instruction-label">The salad:&#13;</div><li id="zlrecipe-instruction-3" class="instruction" itemprop="recipeInstructions">Prepare a bowl of ice water.&#13;</li><li id="zlrecipe-instruction-4" class="instruction" itemprop="recipeInstructions">Set a large saucepan of water over high heat, and bring the water to a boil.  Add the shrimp and boil until the shrimp is just cooked through, 60 to 75 seconds.  Drain and immediately plunge the shrimp into the ice water to stop them from cooking further.  Drain&#13;</li><li id="zlrecipe-instruction-5" class="instruction" itemprop="recipeInstructions">In a medium bowl, mix together the shrimp, cucumber, avocado and cilantro.  Pour in the dressing and toss to combine.  Serve.</li></ol><p id="zlrecipe-notes" class="h-4 strong">Notes</p><div id="zlrecipe-notes-list"><p class="notes">Calories 201.2 / Total Fat 5.4g / Saturated Fat 0.9g / Cholesterol 172.3mg / Sodium 1045.3mg / Total Carbohydrates 13.8g / Fiber 1.9g / Sugar 9.2g / Protein 24.3g / WW (Old Points) 4 / WW (Points+) 5</p></div><div class="zl-linkback" style="display: none;">Schema/Recipe SEO Data Markup by <a title="ZipList Recipe Plugin" alt="ZipList Recipe Plugin" href="http://www.ziplist.com/recipe_plugin" target="_blank">ZipList Recipe Plugin</a></div><div class="ziplist-recipe-plugin" style="display: none;">2.0</div></div></div>&#13;
+		</div>
+<p><a href="http://www.mylivesignature.com/" target="_blank"><img style="border: 0pt none ! important; background: none repeat scroll 0% 0% transparent;" src="http://signatures.mylivesignature.com/54488/288/7998C9A5C7F5AB886291DBD39050A1A9.png" alt="" /></a></p>
+<div class="linkwithin_hook" id="http://www.cookincanuck.com/2013/04/10-minute-thai-shrimp-cucumber-avocado-salad-recipe/"></div><script>
+&lt;!-- //LinkWithinCodeStart
+var linkwithin_site_id = 533415;
+var linkwithin_div_class = "linkwithin_hook";
+//LinkWithinCodeEnd --&gt;
+</script><script src="http://www.linkwithin.com/widget.js"></script><a href="http://www.linkwithin.com/"><img src="http://www.linkwithin.com/pixel.png" alt="Related Posts Plugin for WordPress, Blogger..." style="border: 0" /></a><div class="pin-it-btn-wrapper"><table class="pib-count-table pib-count-table-horizontal"><tbody><tr><td><a href="http://pinterest.com/pin/create/button/?url=http%3A%2F%2Fwww.cookincanuck.com%2F2013%2F04%2F10-minute-thai-shrimp-cucumber-avocado-salad-recipe%2F&amp;media=http%3A%2F%2Ffarm9.staticflickr.com%2F8255%2F8636959668_73ab6460b3_c.jpg&amp;description=10-Minute%20Thai%20Shrimp%2C%20Cucumber%20%26%23038%3B%20Avocado%20Salad%20Recipe" count-layout="horizontal" class="pin-it-button-no-iframe pin-it-button-user-selects-image" rel="nobox"><img border="0" class="pib-count-img" src="//assets.pinterest.com/images/PinExt.png" title="Pin It" /></a></td>
+<td class="pib-count-cell"><div class="pib-count-bubble"></div></td>
+</tr></tbody></table></div><div class="shr-publisher-9722"></div><!-- Start Shareaholic LikeButtonSetBottom Automatic --><div style="clear: both; min-height: 1px; height: 3px; width: 100%;"></div><div class="shareaholic-like-buttonset" style="float:none;height:30px;"><a class="shareaholic-fblike" data-shr_layout="button_count" data-shr_showfaces="false" data-shr_href="http%3A%2F%2Fwww.cookincanuck.com%2F2013%2F04%2F10-minute-thai-shrimp-cucumber-avocado-salad-recipe%2F" data-shr_title="10-Minute+Thai+Shrimp%2C+Cucumber+%26+Avocado+Salad+Recipe+"></a><a class="shareaholic-googleplusone" data-shr_size="medium" data-shr_count="true" data-shr_href="http%3A%2F%2Fwww.cookincanuck.com%2F2013%2F04%2F10-minute-thai-shrimp-cucumber-avocado-salad-recipe%2F" data-shr_title="10-Minute+Thai+Shrimp%2C+Cucumber+%26+Avocado+Salad+Recipe+"></a><a class="shareaholic-tweetbutton" data-shr_count="horizontal" data-shr_href="http%3A%2F%2Fwww.cookincanuck.com%2F2013%2F04%2F10-minute-thai-shrimp-cucumber-avocado-salad-recipe%2F" data-shr_title="10-Minute+Thai+Shrimp%2C+Cucumber+%26+Avocado+Salad+Recipe+"></a></div><div style="clear: both; min-height: 1px; height: 3px; width: 100%;"></div><!-- End Shareaholic LikeButtonSetBottom Automatic -->					<p class="post_tags">Tagged as:
+						<a href="http://www.cookincanuck.com/tag/avocado/" rel="tag nofollow">avocado</a>, 
+						<a href="http://www.cookincanuck.com/tag/cucumber/" rel="tag nofollow">cucumber</a>, 
+						<a href="http://www.cookincanuck.com/tag/healthy/" rel="tag nofollow">healthy</a>, 
+						<a href="http://www.cookincanuck.com/tag/low-calorie/" rel="tag nofollow">low-calorie</a>, 
+						<a href="http://www.cookincanuck.com/tag/low-fat/" rel="tag nofollow">low-fat</a>, 
+						<a href="http://www.cookincanuck.com/tag/recipe/" rel="tag nofollow">recipe</a>, 
+						<a href="http://www.cookincanuck.com/tag/salad/" rel="tag nofollow">salad</a>, 
+						<a href="http://www.cookincanuck.com/tag/seafood/" rel="tag nofollow">seafood</a>, 
+						<a href="http://www.cookincanuck.com/tag/shrimp/" rel="tag nofollow">shrimp</a>, 
+						<a href="http://www.cookincanuck.com/tag/thai/" rel="tag nofollow">Thai</a>
+					</p>
+<!-- Begin supplemental 300 ad -->&#13;
+<script src="http://ads.blogherads.com/63/6348/300nh.js" type="text/javascript"></script><!-- End supplemental 300 ad --><script type="text/javascript" src="http://www.googletagservices.com/tag/js/gpt.js">var pb_ord = Math.floor(Math.random()*10000000000000001);googletag.defineSlot('/15704463/Cookin_Canuck/non-homepage/btf_ct',[[300,250]],'div-non-homepage-btf_ct' + pb_ord ).addService(googletag.pubads());googletag.pubads().enableSyncRendering();googletag.enableServices();googletag.display('div-non-homepage-btf_ct' + pb_ord);</script></div>
+			</div>
+
+			<div id="comments">
+				<div id="comments_intro" class="comments_intro">
+					<p><span class="bracket">{</span> <span>27</span> comments&#8230; read them below or <a href="#respond" rel="nofollow">add one</a> <span class="bracket">}</span></p>
+				</div>
+
+				<dl id="comment_list"><dt class="comment even thread-even depth-1" id="comment-214142">
+<span class="avatar"><a href="http://www.kalynskitchen.com" rel="nofollow"><img alt="" src="http://1.gravatar.com/avatar/d24156669d5962deb7fdc31688282e65?s=66&amp;d=http%3A%2F%2Fwww.cookincanuck.com%2Fwp-content%2Fthemes%2Fthesis_18%2Fcustom%2Fimages%2Fcc_avatar.jpg%3Fs%3D66&amp;r=G" class="avatar avatar-66 photo" height="66" width="66" /></a></span>
+<span class="comment_num"><a href="#comment-214142" title="Permalink to this comment" rel="nofollow">1</a></span>
+<span class="comment_author"><a href="http://www.kalynskitchen.com" rel="external nofollow" class="url">Kalyn</a></span>
+<span class="comment_time">April 11, 2013 at 6:10 am</span>
+
+					</dt>
+					<dd class="comment even thread-even depth-1">
+<div class="format_text" id="comment-body-214142">
+<p>I love the sound of this salad, especially the dressing.  Sounds like a perfect lunch to me.</p>
+<p class="reply"><a class="comment-reply-link" href="/2013/04/10-minute-thai-shrimp-cucumber-avocado-salad-recipe/?replytocom=214142#respond" onclick="return addComment.moveForm(&quot;comment-body-214142&quot;, &quot;214142&quot;, &quot;respond&quot;, &quot;9722&quot;)">Reply</a></p>
+</div>
+					</dd>
+					<dt class="comment odd alt thread-odd thread-alt depth-1" id="comment-214144">
+<span class="avatar"><a href="http://www.thelemonbowl.com" rel="nofollow"><img alt="" src="http://1.gravatar.com/avatar/519b2496ec532f34042e80f42cc86c1f?s=66&amp;d=http%3A%2F%2Fwww.cookincanuck.com%2Fwp-content%2Fthemes%2Fthesis_18%2Fcustom%2Fimages%2Fcc_avatar.jpg%3Fs%3D66&amp;r=G" class="avatar avatar-66 photo" height="66" width="66" /></a></span>
+<span class="comment_num"><a href="#comment-214144" title="Permalink to this comment" rel="nofollow">2</a></span>
+<span class="comment_author"><a href="http://www.thelemonbowl.com" rel="external nofollow" class="url">Liz @ The Lemon Bowl</a></span>
+<span class="comment_time">April 11, 2013 at 6:17 am</span>
+
+					</dt>
+					<dd class="comment odd alt thread-odd thread-alt depth-1">
+<div class="format_text" id="comment-body-214144">
+<p>I can&#8217;t get over how beautiful your shrimp looks!!! Love the simplicity of this flavorful salad!</p>
+<p class="reply"><a class="comment-reply-link" href="/2013/04/10-minute-thai-shrimp-cucumber-avocado-salad-recipe/?replytocom=214144#respond" onclick="return addComment.moveForm(&quot;comment-body-214144&quot;, &quot;214144&quot;, &quot;respond&quot;, &quot;9722&quot;)">Reply</a></p>
+</div>
+					</dd>
+					<dt class="comment even thread-even depth-1" id="comment-214149">
+<span class="avatar"><a href="http://www.halfbakedharvest.com/" rel="nofollow"><img alt="" src="http://0.gravatar.com/avatar/49ee4a23a1d5dffb1944da32800bb254?s=66&amp;d=http%3A%2F%2Fwww.cookincanuck.com%2Fwp-content%2Fthemes%2Fthesis_18%2Fcustom%2Fimages%2Fcc_avatar.jpg%3Fs%3D66&amp;r=G" class="avatar avatar-66 photo" height="66" width="66" /></a></span>
+<span class="comment_num"><a href="#comment-214149" title="Permalink to this comment" rel="nofollow">3</a></span>
+<span class="comment_author"><a href="http://www.halfbakedharvest.com/" rel="external nofollow" class="url">Tieghan</a></span>
+<span class="comment_time">April 11, 2013 at 6:40 am</span>
+
+					</dt>
+					<dd class="comment even thread-even depth-1">
+<div class="format_text" id="comment-body-214149">
+<p>Thai shrimp!!! Yes, please! These look and sound awesome! I have a serious obsession with thai food right now. It is getting out of hand.</p>
+<p class="reply"><a class="comment-reply-link" href="/2013/04/10-minute-thai-shrimp-cucumber-avocado-salad-recipe/?replytocom=214149#respond" onclick="return addComment.moveForm(&quot;comment-body-214149&quot;, &quot;214149&quot;, &quot;respond&quot;, &quot;9722&quot;)">Reply</a></p>
+</div>
+					</dd>
+					<dt class="comment odd alt thread-odd thread-alt depth-1" id="comment-214157">
+<span class="avatar"><a href="http://cookiesandcups.com" rel="nofollow"><img alt="" src="http://1.gravatar.com/avatar/506c16916fbf1c4bfcb0b3e64b1e94bb?s=66&amp;d=http%3A%2F%2Fwww.cookincanuck.com%2Fwp-content%2Fthemes%2Fthesis_18%2Fcustom%2Fimages%2Fcc_avatar.jpg%3Fs%3D66&amp;r=G" class="avatar avatar-66 photo" height="66" width="66" /></a></span>
+<span class="comment_num"><a href="#comment-214157" title="Permalink to this comment" rel="nofollow">4</a></span>
+<span class="comment_author"><a href="http://cookiesandcups.com" rel="external nofollow" class="url">shelly (cookies and cups)</a></span>
+<span class="comment_time">April 11, 2013 at 6:58 am</span>
+
+					</dt>
+					<dd class="comment odd alt thread-odd thread-alt depth-1">
+<div class="format_text" id="comment-body-214157">
+<p>I&#8217;m making this.  And not sharing.</p>
+<p class="reply"><a class="comment-reply-link" href="/2013/04/10-minute-thai-shrimp-cucumber-avocado-salad-recipe/?replytocom=214157#respond" onclick="return addComment.moveForm(&quot;comment-body-214157&quot;, &quot;214157&quot;, &quot;respond&quot;, &quot;9722&quot;)">Reply</a></p>
+</div>
+					</dd>
+					<dt class="comment even thread-even depth-1" id="comment-214159">
+<span class="avatar"><a href="http://www.foodnessgracious.com" rel="nofollow"><img alt="" src="http://1.gravatar.com/avatar/1fad9967f7bc314093e474a80902ee3d?s=66&amp;d=http%3A%2F%2Fwww.cookincanuck.com%2Fwp-content%2Fthemes%2Fthesis_18%2Fcustom%2Fimages%2Fcc_avatar.jpg%3Fs%3D66&amp;r=G" class="avatar avatar-66 photo" height="66" width="66" /></a></span>
+<span class="comment_num"><a href="#comment-214159" title="Permalink to this comment" rel="nofollow">5</a></span>
+<span class="comment_author"><a href="http://www.foodnessgracious.com" rel="external nofollow" class="url">Gerry @ Foodness Gracious</a></span>
+<span class="comment_time">April 11, 2013 at 7:12 am</span>
+
+					</dt>
+					<dd class="comment even thread-even depth-1">
+<div class="format_text" id="comment-body-214159">
+<p>Looks super fresh, my kinda dealio!</p>
+<p class="reply"><a class="comment-reply-link" href="/2013/04/10-minute-thai-shrimp-cucumber-avocado-salad-recipe/?replytocom=214159#respond" onclick="return addComment.moveForm(&quot;comment-body-214159&quot;, &quot;214159&quot;, &quot;respond&quot;, &quot;9722&quot;)">Reply</a></p>
+</div>
+					</dd>
+					<dt class="comment odd alt thread-odd thread-alt depth-1" id="comment-214160">
+<span class="avatar"><a href="http://www.loavesndishes.com" rel="nofollow"><img alt="" src="http://1.gravatar.com/avatar/3353f69e9e0e2db51355fb2c84cb9c75?s=66&amp;d=http%3A%2F%2Fwww.cookincanuck.com%2Fwp-content%2Fthemes%2Fthesis_18%2Fcustom%2Fimages%2Fcc_avatar.jpg%3Fs%3D66&amp;r=G" class="avatar avatar-66 photo" height="66" width="66" /></a></span>
+<span class="comment_num"><a href="#comment-214160" title="Permalink to this comment" rel="nofollow">6</a></span>
+<span class="comment_author"><a href="http://www.loavesndishes.com" rel="external nofollow" class="url">Kari@Loaves n Dishes</a></span>
+<span class="comment_time">April 11, 2013 at 7:14 am</span>
+
+					</dt>
+					<dd class="comment odd alt thread-odd thread-alt depth-1">
+<div class="format_text" id="comment-body-214160">
+<p>I love that this dish is super quick to make, yet it&#8217;s still packed full of flavor!</p>
+<p class="reply"><a class="comment-reply-link" href="/2013/04/10-minute-thai-shrimp-cucumber-avocado-salad-recipe/?replytocom=214160#respond" onclick="return addComment.moveForm(&quot;comment-body-214160&quot;, &quot;214160&quot;, &quot;respond&quot;, &quot;9722&quot;)">Reply</a></p>
+</div>
+					</dd>
+					<dt class="comment even thread-even depth-1" id="comment-214169">
+<span class="avatar"><a href="http://www.bevcooks.com" rel="nofollow"><img alt="" src="http://1.gravatar.com/avatar/1d1e79dee216f2bc41b2c9f8cf5496e8?s=66&amp;d=http%3A%2F%2Fwww.cookincanuck.com%2Fwp-content%2Fthemes%2Fthesis_18%2Fcustom%2Fimages%2Fcc_avatar.jpg%3Fs%3D66&amp;r=G" class="avatar avatar-66 photo" height="66" width="66" /></a></span>
+<span class="comment_num"><a href="#comment-214169" title="Permalink to this comment" rel="nofollow">7</a></span>
+<span class="comment_author"><a href="http://www.bevcooks.com" rel="external nofollow" class="url">Bev @ Bev Cooks</a></span>
+<span class="comment_time">April 11, 2013 at 7:38 am</span>
+
+					</dt>
+					<dd class="comment even thread-even depth-1">
+<div class="format_text" id="comment-body-214169">
+<p>Fish sauce rules my life, sooooo this is basically a done deal.</p>
+<p class="reply"><a class="comment-reply-link" href="/2013/04/10-minute-thai-shrimp-cucumber-avocado-salad-recipe/?replytocom=214169#respond" onclick="return addComment.moveForm(&quot;comment-body-214169&quot;, &quot;214169&quot;, &quot;respond&quot;, &quot;9722&quot;)">Reply</a></p>
+</div>
+					</dd>
+					<dt class="comment odd alt thread-odd thread-alt depth-1" id="comment-214173">
+<span class="avatar"><a href="http://bakeyourday.net" rel="nofollow"><img alt="" src="http://0.gravatar.com/avatar/aa5caa5103138d2e0db649031d43fd72?s=66&amp;d=http%3A%2F%2Fwww.cookincanuck.com%2Fwp-content%2Fthemes%2Fthesis_18%2Fcustom%2Fimages%2Fcc_avatar.jpg%3Fs%3D66&amp;r=G" class="avatar avatar-66 photo" height="66" width="66" /></a></span>
+<span class="comment_num"><a href="#comment-214173" title="Permalink to this comment" rel="nofollow">8</a></span>
+<span class="comment_author"><a href="http://bakeyourday.net" rel="external nofollow" class="url">Cassie | Bake Your Day</a></span>
+<span class="comment_time">April 11, 2013 at 7:46 am</span>
+
+					</dt>
+					<dd class="comment odd alt thread-odd thread-alt depth-1">
+<div class="format_text" id="comment-body-214173">
+<p>Fabulous salad, Dara. I can&#8217;t get over the flavors of the dressing!</p>
+<p class="reply"><a class="comment-reply-link" href="/2013/04/10-minute-thai-shrimp-cucumber-avocado-salad-recipe/?replytocom=214173#respond" onclick="return addComment.moveForm(&quot;comment-body-214173&quot;, &quot;214173&quot;, &quot;respond&quot;, &quot;9722&quot;)">Reply</a></p>
+</div>
+					</dd>
+					<dt class="comment even thread-even depth-1" id="comment-214175">
+<span class="avatar"><a href="http://www.familyfreshcooking.com/" rel="nofollow"><img alt="" src="http://1.gravatar.com/avatar/f8335a64d561f273b44ad0fb5ced3703?s=66&amp;d=http%3A%2F%2Fwww.cookincanuck.com%2Fwp-content%2Fthemes%2Fthesis_18%2Fcustom%2Fimages%2Fcc_avatar.jpg%3Fs%3D66&amp;r=G" class="avatar avatar-66 photo" height="66" width="66" /></a></span>
+<span class="comment_num"><a href="#comment-214175" title="Permalink to this comment" rel="nofollow">9</a></span>
+<span class="comment_author"><a href="http://www.familyfreshcooking.com/" rel="external nofollow" class="url">marla</a></span>
+<span class="comment_time">April 11, 2013 at 7:52 am</span>
+
+					</dt>
+					<dd class="comment even thread-even depth-1">
+<div class="format_text" id="comment-body-214175">
+<p>10 minutes for this great salad? I&#8217;m in!</p>
+<p class="reply"><a class="comment-reply-link" href="/2013/04/10-minute-thai-shrimp-cucumber-avocado-salad-recipe/?replytocom=214175#respond" onclick="return addComment.moveForm(&quot;comment-body-214175&quot;, &quot;214175&quot;, &quot;respond&quot;, &quot;9722&quot;)">Reply</a></p>
+</div>
+					</dd>
+					<dt class="comment odd alt thread-odd thread-alt depth-1" id="comment-214184">
+<span class="avatar"><a href="http://www.thewayfaringbaker.com" rel="nofollow"><img alt="" src="http://0.gravatar.com/avatar/4e3debe28d65e84e82e57da1ed303fa1?s=66&amp;d=http%3A%2F%2Fwww.cookincanuck.com%2Fwp-content%2Fthemes%2Fthesis_18%2Fcustom%2Fimages%2Fcc_avatar.jpg%3Fs%3D66&amp;r=G" class="avatar avatar-66 photo" height="66" width="66" /></a></span>
+<span class="comment_num"><a href="#comment-214184" title="Permalink to this comment" rel="nofollow">10</a></span>
+<span class="comment_author"><a href="http://www.thewayfaringbaker.com" rel="external nofollow" class="url">Elle</a></span>
+<span class="comment_time">April 11, 2013 at 8:27 am</span>
+
+					</dt>
+					<dd class="comment odd alt thread-odd thread-alt depth-1">
+<div class="format_text" id="comment-body-214184">
+<p>Sounds delicious and just what I need for work lunches &#8211; little prep and very delicious! Thank you!</p>
+<p class="reply"><a class="comment-reply-link" href="/2013/04/10-minute-thai-shrimp-cucumber-avocado-salad-recipe/?replytocom=214184#respond" onclick="return addComment.moveForm(&quot;comment-body-214184&quot;, &quot;214184&quot;, &quot;respond&quot;, &quot;9722&quot;)">Reply</a></p>
+</div>
+					</dd>
+					<dt class="comment even thread-even depth-1" id="comment-214212">
+<span class="avatar"><a href="http://www.carlasconfections.com" rel="nofollow"><img alt="" src="http://0.gravatar.com/avatar/2397312a161d6414e2d5a591d1ae9d67?s=66&amp;d=http%3A%2F%2Fwww.cookincanuck.com%2Fwp-content%2Fthemes%2Fthesis_18%2Fcustom%2Fimages%2Fcc_avatar.jpg%3Fs%3D66&amp;r=G" class="avatar avatar-66 photo" height="66" width="66" /></a></span>
+<span class="comment_num"><a href="#comment-214212" title="Permalink to this comment" rel="nofollow">11</a></span>
+<span class="comment_author"><a href="http://www.carlasconfections.com" rel="external nofollow" class="url">Carla @ Carlas Confections</a></span>
+<span class="comment_time">April 11, 2013 at 9:42 am</span>
+
+					</dt>
+					<dd class="comment even thread-even depth-1">
+<div class="format_text" id="comment-body-214212">
+<p>I am LOVING how fresh that looks! I cant wait to make this!! <img src="http://www.cookincanuck.com/wp-includes/images/smilies/icon_smile.gif" alt=":)" class="wp-smiley" /></p>
+<p class="reply"><a class="comment-reply-link" href="/2013/04/10-minute-thai-shrimp-cucumber-avocado-salad-recipe/?replytocom=214212#respond" onclick="return addComment.moveForm(&quot;comment-body-214212&quot;, &quot;214212&quot;, &quot;respond&quot;, &quot;9722&quot;)">Reply</a></p>
+</div>
+					</dd>
+					<dt class="comment odd alt thread-odd thread-alt depth-1" id="comment-214221">
+<span class="avatar"><a href="http://tutti-dolci.com" rel="nofollow"><img alt="" src="http://0.gravatar.com/avatar/e8c1ba705f297443f178cf4d2ca19f03?s=66&amp;d=http%3A%2F%2Fwww.cookincanuck.com%2Fwp-content%2Fthemes%2Fthesis_18%2Fcustom%2Fimages%2Fcc_avatar.jpg%3Fs%3D66&amp;r=G" class="avatar avatar-66 photo" height="66" width="66" /></a></span>
+<span class="comment_num"><a href="#comment-214221" title="Permalink to this comment" rel="nofollow">12</a></span>
+<span class="comment_author"><a href="http://tutti-dolci.com" rel="external nofollow" class="url">Laura (Tutti Dolci)</a></span>
+<span class="comment_time">April 11, 2013 at 9:57 am</span>
+
+					</dt>
+					<dd class="comment odd alt thread-odd thread-alt depth-1">
+<div class="format_text" id="comment-body-214221">
+<p>Love this salad, Dara &#8211; it looks so tasty and refreshing!</p>
+<p class="reply"><a class="comment-reply-link" href="/2013/04/10-minute-thai-shrimp-cucumber-avocado-salad-recipe/?replytocom=214221#respond" onclick="return addComment.moveForm(&quot;comment-body-214221&quot;, &quot;214221&quot;, &quot;respond&quot;, &quot;9722&quot;)">Reply</a></p>
+</div>
+					</dd>
+					<dt class="comment even thread-even depth-1" id="comment-214226">
+<span class="avatar"><a href="http://www.gooddinnermom.com" rel="nofollow"><img alt="" src="http://1.gravatar.com/avatar/78ac580fec2d72c96392b446cdad2f61?s=66&amp;d=http%3A%2F%2Fwww.cookincanuck.com%2Fwp-content%2Fthemes%2Fthesis_18%2Fcustom%2Fimages%2Fcc_avatar.jpg%3Fs%3D66&amp;r=G" class="avatar avatar-66 photo" height="66" width="66" /></a></span>
+<span class="comment_num"><a href="#comment-214226" title="Permalink to this comment" rel="nofollow">13</a></span>
+<span class="comment_author"><a href="http://www.gooddinnermom.com" rel="external nofollow" class="url">Sally@gooddinnermom</a></span>
+<span class="comment_time">April 11, 2013 at 10:15 am</span>
+
+					</dt>
+					<dd class="comment even thread-even depth-1">
+<div class="format_text" id="comment-body-214226">
+<p>Ooooh, delicious and refreshing! Thanks for the recipe. <img src="http://www.cookincanuck.com/wp-includes/images/smilies/icon_smile.gif" alt=":)" class="wp-smiley" /></p>
+<p class="reply"><a class="comment-reply-link" href="/2013/04/10-minute-thai-shrimp-cucumber-avocado-salad-recipe/?replytocom=214226#respond" onclick="return addComment.moveForm(&quot;comment-body-214226&quot;, &quot;214226&quot;, &quot;respond&quot;, &quot;9722&quot;)">Reply</a></p>
+</div>
+					</dd>
+					<dt class="comment odd alt thread-odd thread-alt depth-1" id="comment-214247">
+<span class="avatar"><a href="http://culicurious.com" rel="nofollow"><img alt="" src="http://1.gravatar.com/avatar/56f9badb4776d3135e468833f8d16347?s=66&amp;d=http%3A%2F%2Fwww.cookincanuck.com%2Fwp-content%2Fthemes%2Fthesis_18%2Fcustom%2Fimages%2Fcc_avatar.jpg%3Fs%3D66&amp;r=G" class="avatar avatar-66 photo" height="66" width="66" /></a></span>
+<span class="comment_num"><a href="#comment-214247" title="Permalink to this comment" rel="nofollow">14</a></span>
+<span class="comment_author"><a href="http://culicurious.com" rel="external nofollow" class="url">addie | culicurious</a></span>
+<span class="comment_time">April 11, 2013 at 11:50 am</span>
+
+					</dt>
+					<dd class="comment odd alt thread-odd thread-alt depth-1">
+<div class="format_text" id="comment-body-214247">
+<p>This looks fantastic, Dara. Those large shrimp are so pretty! Great lunch dish!!</p>
+<p class="reply"><a class="comment-reply-link" href="/2013/04/10-minute-thai-shrimp-cucumber-avocado-salad-recipe/?replytocom=214247#respond" onclick="return addComment.moveForm(&quot;comment-body-214247&quot;, &quot;214247&quot;, &quot;respond&quot;, &quot;9722&quot;)">Reply</a></p>
+</div>
+					</dd>
+					<dt class="comment even thread-even depth-1" id="comment-214349">
+<span class="avatar"><a href="http://jeanetteshealthyliving.com" rel="nofollow"><img alt="" src="http://0.gravatar.com/avatar/c98d9d360fb3a0a24e7c909d42d62809?s=66&amp;d=http%3A%2F%2Fwww.cookincanuck.com%2Fwp-content%2Fthemes%2Fthesis_18%2Fcustom%2Fimages%2Fcc_avatar.jpg%3Fs%3D66&amp;r=G" class="avatar avatar-66 photo" height="66" width="66" /></a></span>
+<span class="comment_num"><a href="#comment-214349" title="Permalink to this comment" rel="nofollow">15</a></span>
+<span class="comment_author"><a href="http://jeanetteshealthyliving.com" rel="external nofollow" class="url">Jeanette</a></span>
+<span class="comment_time">April 11, 2013 at 6:08 pm</span>
+
+					</dt>
+					<dd class="comment even thread-even depth-1">
+<div class="format_text" id="comment-body-214349">
+<p>What a beautiful lunch Dara &#8211; and I love that it only takes 10 minutes!</p>
+<p class="reply"><a class="comment-reply-link" href="/2013/04/10-minute-thai-shrimp-cucumber-avocado-salad-recipe/?replytocom=214349#respond" onclick="return addComment.moveForm(&quot;comment-body-214349&quot;, &quot;214349&quot;, &quot;respond&quot;, &quot;9722&quot;)">Reply</a></p>
+</div>
+					</dd>
+					<dt class="comment odd alt thread-odd thread-alt depth-1" id="comment-214571">
+<span class="avatar"><a href="http://www.bellalimento.com" rel="nofollow"><img alt="" src="http://1.gravatar.com/avatar/5b6a4a086dfdb7b7ca39cb12a438423e?s=66&amp;d=http%3A%2F%2Fwww.cookincanuck.com%2Fwp-content%2Fthemes%2Fthesis_18%2Fcustom%2Fimages%2Fcc_avatar.jpg%3Fs%3D66&amp;r=G" class="avatar avatar-66 photo" height="66" width="66" /></a></span>
+<span class="comment_num"><a href="#comment-214571" title="Permalink to this comment" rel="nofollow">16</a></span>
+<span class="comment_author"><a href="http://www.bellalimento.com" rel="external nofollow" class="url">Paula - bell'alimento</a></span>
+<span class="comment_time">April 12, 2013 at 11:05 am</span>
+
+					</dt>
+					<dd class="comment odd alt thread-odd thread-alt depth-1">
+<div class="format_text" id="comment-body-214571">
+<p>I&#8217;m going to need an extra bowl please ; )</p>
+<p class="reply"><a class="comment-reply-link" href="/2013/04/10-minute-thai-shrimp-cucumber-avocado-salad-recipe/?replytocom=214571#respond" onclick="return addComment.moveForm(&quot;comment-body-214571&quot;, &quot;214571&quot;, &quot;respond&quot;, &quot;9722&quot;)">Reply</a></p>
+</div>
+					</dd>
+					<dt class="comment even thread-even depth-1" id="comment-214572">
+<span class="avatar"><a href="http://eclecticrecipes.com" rel="nofollow"><img alt="" src="http://1.gravatar.com/avatar/100e9551ee8cda41c96ed26b042cd1f5?s=66&amp;d=http%3A%2F%2Fwww.cookincanuck.com%2Fwp-content%2Fthemes%2Fthesis_18%2Fcustom%2Fimages%2Fcc_avatar.jpg%3Fs%3D66&amp;r=G" class="avatar avatar-66 photo" height="66" width="66" /></a></span>
+<span class="comment_num"><a href="#comment-214572" title="Permalink to this comment" rel="nofollow">17</a></span>
+<span class="comment_author"><a href="http://eclecticrecipes.com" rel="external nofollow" class="url">Angie</a></span>
+<span class="comment_time">April 12, 2013 at 11:06 am</span>
+
+					</dt>
+					<dd class="comment even thread-even depth-1">
+<div class="format_text" id="comment-body-214572">
+<p>Gorgeous photos! I love fast shrimp recipes, can&#8217;t wait to try this!</p>
+<p class="reply"><a class="comment-reply-link" href="/2013/04/10-minute-thai-shrimp-cucumber-avocado-salad-recipe/?replytocom=214572#respond" onclick="return addComment.moveForm(&quot;comment-body-214572&quot;, &quot;214572&quot;, &quot;respond&quot;, &quot;9722&quot;)">Reply</a></p>
+</div>
+					</dd>
+					<dt class="comment odd alt thread-odd thread-alt depth-1" id="comment-214586">
+<span class="avatar"><a href="http://www.myinvisiblecrown.com" rel="nofollow"><img alt="" src="http://0.gravatar.com/avatar/e2a0542c440fdd15045dace039447788?s=66&amp;d=http%3A%2F%2Fwww.cookincanuck.com%2Fwp-content%2Fthemes%2Fthesis_18%2Fcustom%2Fimages%2Fcc_avatar.jpg%3Fs%3D66&amp;r=G" class="avatar avatar-66 photo" height="66" width="66" /></a></span>
+<span class="comment_num"><a href="#comment-214586" title="Permalink to this comment" rel="nofollow">18</a></span>
+<span class="comment_author"><a href="http://www.myinvisiblecrown.com" rel="external nofollow" class="url">Christy @ My Invisible Crown</a></span>
+<span class="comment_time">April 12, 2013 at 1:56 pm</span>
+
+					</dt>
+					<dd class="comment odd alt thread-odd thread-alt depth-1">
+<div class="format_text" id="comment-body-214586">
+<p>Oh this sounds so good!  I love Thai flavors and anything with avocado.  It&#8217;s light and healthy and looks so simple.  Love it!</p>
+<p class="reply"><a class="comment-reply-link" href="/2013/04/10-minute-thai-shrimp-cucumber-avocado-salad-recipe/?replytocom=214586#respond" onclick="return addComment.moveForm(&quot;comment-body-214586&quot;, &quot;214586&quot;, &quot;respond&quot;, &quot;9722&quot;)">Reply</a></p>
+</div>
+					</dd>
+					<dt class="comment even thread-even depth-1" id="comment-214597">
+<span class="avatar"><a href="http://www.a-kitchen-addiction.com" rel="nofollow"><img alt="" src="http://0.gravatar.com/avatar/4549592d7a9d0d626c84e129477bfa9c?s=66&amp;d=http%3A%2F%2Fwww.cookincanuck.com%2Fwp-content%2Fthemes%2Fthesis_18%2Fcustom%2Fimages%2Fcc_avatar.jpg%3Fs%3D66&amp;r=G" class="avatar avatar-66 photo" height="66" width="66" /></a></span>
+<span class="comment_num"><a href="#comment-214597" title="Permalink to this comment" rel="nofollow">19</a></span>
+<span class="comment_author"><a href="http://www.a-kitchen-addiction.com" rel="external nofollow" class="url">Jessica@AKitchenAddiction</a></span>
+<span class="comment_time">April 12, 2013 at 2:52 pm</span>
+
+					</dt>
+					<dd class="comment even thread-even depth-1">
+<div class="format_text" id="comment-body-214597">
+<p>There is nothing boring about this salad! It looks so fresh and delicious!</p>
+<p class="reply"><a class="comment-reply-link" href="/2013/04/10-minute-thai-shrimp-cucumber-avocado-salad-recipe/?replytocom=214597#respond" onclick="return addComment.moveForm(&quot;comment-body-214597&quot;, &quot;214597&quot;, &quot;respond&quot;, &quot;9722&quot;)">Reply</a></p>
+</div>
+					</dd>
+					<dt class="comment odd alt thread-odd thread-alt depth-1" id="comment-214600">
+<span class="avatar"><a href="http://www.thecomfortofcooking.com" rel="nofollow"><img alt="" src="http://1.gravatar.com/avatar/fcbd2da7d54440ab70362719ff4177ef?s=66&amp;d=http%3A%2F%2Fwww.cookincanuck.com%2Fwp-content%2Fthemes%2Fthesis_18%2Fcustom%2Fimages%2Fcc_avatar.jpg%3Fs%3D66&amp;r=G" class="avatar avatar-66 photo" height="66" width="66" /></a></span>
+<span class="comment_num"><a href="#comment-214600" title="Permalink to this comment" rel="nofollow">20</a></span>
+<span class="comment_author"><a href="http://www.thecomfortofcooking.com" rel="external nofollow" class="url">Georgia @ The Comfort of Cooking</a></span>
+<span class="comment_time">April 12, 2013 at 3:05 pm</span>
+
+					</dt>
+					<dd class="comment odd alt thread-odd thread-alt depth-1">
+<div class="format_text" id="comment-body-214600">
+<p>How fabulous is this? I love how easy it is too. The easier the better in the spring/summer!</p>
+<p class="reply"><a class="comment-reply-link" href="/2013/04/10-minute-thai-shrimp-cucumber-avocado-salad-recipe/?replytocom=214600#respond" onclick="return addComment.moveForm(&quot;comment-body-214600&quot;, &quot;214600&quot;, &quot;respond&quot;, &quot;9722&quot;)">Reply</a></p>
+</div>
+					</dd>
+					<dt class="comment even thread-even depth-1" id="comment-214643">
+<span class="avatar"><a href="http://www.nutmegnanny.com" rel="nofollow"><img alt="" src="http://0.gravatar.com/avatar/02d5844dd5ba7c6845858715bc120658?s=66&amp;d=http%3A%2F%2Fwww.cookincanuck.com%2Fwp-content%2Fthemes%2Fthesis_18%2Fcustom%2Fimages%2Fcc_avatar.jpg%3Fs%3D66&amp;r=G" class="avatar avatar-66 photo" height="66" width="66" /></a></span>
+<span class="comment_num"><a href="#comment-214643" title="Permalink to this comment" rel="nofollow">21</a></span>
+<span class="comment_author"><a href="http://www.nutmegnanny.com" rel="external nofollow" class="url">Nutmeg Nanny</a></span>
+<span class="comment_time">April 12, 2013 at 7:57 pm</span>
+
+					</dt>
+					<dd class="comment even thread-even depth-1">
+<div class="format_text" id="comment-body-214643">
+<p>Yum! This my kind of lunch <img src="http://www.cookincanuck.com/wp-includes/images/smilies/icon_smile.gif" alt=":)" class="wp-smiley" />  it looks so satisfying!</p>
+<p class="reply"><a class="comment-reply-link" href="/2013/04/10-minute-thai-shrimp-cucumber-avocado-salad-recipe/?replytocom=214643#respond" onclick="return addComment.moveForm(&quot;comment-body-214643&quot;, &quot;214643&quot;, &quot;respond&quot;, &quot;9722&quot;)">Reply</a></p>
+</div>
+					</dd>
+					<dt class="comment odd alt thread-odd thread-alt depth-1" id="comment-214856">
+<span class="avatar"><a href="http://www.missinthekitchen.com" rel="nofollow"><img alt="" src="http://1.gravatar.com/avatar/54986f9cd12690a777c929b3fab851d2?s=66&amp;d=http%3A%2F%2Fwww.cookincanuck.com%2Fwp-content%2Fthemes%2Fthesis_18%2Fcustom%2Fimages%2Fcc_avatar.jpg%3Fs%3D66&amp;r=G" class="avatar avatar-66 photo" height="66" width="66" /></a></span>
+<span class="comment_num"><a href="#comment-214856" title="Permalink to this comment" rel="nofollow">22</a></span>
+<span class="comment_author"><a href="http://www.missinthekitchen.com" rel="external nofollow" class="url">Miss @ Miss in the Kitchen</a></span>
+<span class="comment_time">April 13, 2013 at 10:18 pm</span>
+
+					</dt>
+					<dd class="comment odd alt thread-odd thread-alt depth-1">
+<div class="format_text" id="comment-body-214856">
+<p>I can&#8217;t think of anything better for lunch! So simple but so much flavor there.  I just love your recipes!</p>
+<p class="reply"><a class="comment-reply-link" href="/2013/04/10-minute-thai-shrimp-cucumber-avocado-salad-recipe/?replytocom=214856#respond" onclick="return addComment.moveForm(&quot;comment-body-214856&quot;, &quot;214856&quot;, &quot;respond&quot;, &quot;9722&quot;)">Reply</a></p>
+</div>
+					</dd>
+					<dt class="comment even thread-even depth-1" id="comment-214937">
+<span class="avatar"><a href="http://alldayidreamaboutfood.com" rel="nofollow"><img alt="" src="http://0.gravatar.com/avatar/eabc3b615704d4177e50c18982207bc8?s=66&amp;d=http%3A%2F%2Fwww.cookincanuck.com%2Fwp-content%2Fthemes%2Fthesis_18%2Fcustom%2Fimages%2Fcc_avatar.jpg%3Fs%3D66&amp;r=G" class="avatar avatar-66 photo" height="66" width="66" /></a></span>
+<span class="comment_num"><a href="#comment-214937" title="Permalink to this comment" rel="nofollow">23</a></span>
+<span class="comment_author"><a href="http://alldayidreamaboutfood.com" rel="external nofollow" class="url">Carolyn</a></span>
+<span class="comment_time">April 14, 2013 at 9:52 am</span>
+
+					</dt>
+					<dd class="comment even thread-even depth-1">
+<div class="format_text" id="comment-body-214937">
+<p>I LOVE this recipe, Dara.  This is just ideal for me, so fresh.  I am pinning it.</p>
+<p class="reply"><a class="comment-reply-link" href="/2013/04/10-minute-thai-shrimp-cucumber-avocado-salad-recipe/?replytocom=214937#respond" onclick="return addComment.moveForm(&quot;comment-body-214937&quot;, &quot;214937&quot;, &quot;respond&quot;, &quot;9722&quot;)">Reply</a></p>
+</div>
+					</dd>
+					<dt class="comment odd alt thread-odd thread-alt depth-1" id="comment-214951">
+<span class="avatar"><a href="http://www.farmfreshfeasts.com" rel="nofollow"><img alt="" src="http://1.gravatar.com/avatar/383edb70775f46f5a8df1030e4f11560?s=66&amp;d=http%3A%2F%2Fwww.cookincanuck.com%2Fwp-content%2Fthemes%2Fthesis_18%2Fcustom%2Fimages%2Fcc_avatar.jpg%3Fs%3D66&amp;r=G" class="avatar avatar-66 photo" height="66" width="66" /></a></span>
+<span class="comment_num"><a href="#comment-214951" title="Permalink to this comment" rel="nofollow">24</a></span>
+<span class="comment_author"><a href="http://www.farmfreshfeasts.com" rel="external nofollow" class="url">kirsten@FarmFreshFeasts</a></span>
+<span class="comment_time">April 14, 2013 at 11:33 am</span>
+
+					</dt>
+					<dd class="comment odd alt thread-odd thread-alt depth-1">
+<div class="format_text" id="comment-body-214951">
+<p>Dara,<br />
+You&#8217;re so right that when I eat something that satisfies me, that I wanted to eat, I do far better with the afternoon/evening snacking than if I eat something that&#8217;s handy or needs to be &#8216;et up&#8217;.<br />
+This salad looks so cool and inviting, and excellent job on the droplet photo!  That&#8217;s really cool to see, and I bet you were pretty psyched to see it come out so well.<br />
+Thanks!</p>
+<p class="reply"><a class="comment-reply-link" href="/2013/04/10-minute-thai-shrimp-cucumber-avocado-salad-recipe/?replytocom=214951#respond" onclick="return addComment.moveForm(&quot;comment-body-214951&quot;, &quot;214951&quot;, &quot;respond&quot;, &quot;9722&quot;)">Reply</a></p>
+</div>
+					</dd>
+					<dt class="comment even thread-even depth-1" id="comment-215262">
+<span class="avatar"><a href="http://www.crazyforcrust.com" rel="nofollow"><img alt="" src="http://0.gravatar.com/avatar/a5a6cfb181d907c27a4e93da9791049e?s=66&amp;d=http%3A%2F%2Fwww.cookincanuck.com%2Fwp-content%2Fthemes%2Fthesis_18%2Fcustom%2Fimages%2Fcc_avatar.jpg%3Fs%3D66&amp;r=G" class="avatar avatar-66 photo" height="66" width="66" /></a></span>
+<span class="comment_num"><a href="#comment-215262" title="Permalink to this comment" rel="nofollow">25</a></span>
+<span class="comment_author"><a href="http://www.crazyforcrust.com" rel="external nofollow" class="url">Dorothy @ Crazy for Crust</a></span>
+<span class="comment_time">April 15, 2013 at 8:06 pm</span>
+
+					</dt>
+					<dd class="comment even thread-even depth-1">
+<div class="format_text" id="comment-body-215262">
+<p>This sounds like the perfect salad!</p>
+<p class="reply"><a class="comment-reply-link" href="/2013/04/10-minute-thai-shrimp-cucumber-avocado-salad-recipe/?replytocom=215262#respond" onclick="return addComment.moveForm(&quot;comment-body-215262&quot;, &quot;215262&quot;, &quot;respond&quot;, &quot;9722&quot;)">Reply</a></p>
+</div>
+					</dd>
+					<dt class="comment odd alt thread-odd thread-alt depth-1" id="comment-215645">
+<span class="avatar"><a href="http://www.thevintagemixer.com" rel="nofollow"><img alt="" src="http://1.gravatar.com/avatar/71dd5ce40c5703612707ca052cfd9919?s=66&amp;d=http%3A%2F%2Fwww.cookincanuck.com%2Fwp-content%2Fthemes%2Fthesis_18%2Fcustom%2Fimages%2Fcc_avatar.jpg%3Fs%3D66&amp;r=G" class="avatar avatar-66 photo" height="66" width="66" /></a></span>
+<span class="comment_num"><a href="#comment-215645" title="Permalink to this comment" rel="nofollow">26</a></span>
+<span class="comment_author"><a href="http://www.thevintagemixer.com" rel="external nofollow" class="url">Becky at Vintage Mixer</a></span>
+<span class="comment_time">April 16, 2013 at 2:11 pm</span>
+
+					</dt>
+					<dd class="comment odd alt thread-odd thread-alt depth-1">
+<div class="format_text" id="comment-body-215645">
+<p>I&#8217;m all about a 10 minute meal these days!  Great recipe Dara and I&#8217;m so glad to hear than you guys are okay.</p>
+<p class="reply"><a class="comment-reply-link" href="/2013/04/10-minute-thai-shrimp-cucumber-avocado-salad-recipe/?replytocom=215645#respond" onclick="return addComment.moveForm(&quot;comment-body-215645&quot;, &quot;215645&quot;, &quot;respond&quot;, &quot;9722&quot;)">Reply</a></p>
+</div>
+					</dd>
+					<dt class="comment even thread-even depth-1" id="comment-216471">
+<span class="avatar"><a href="http://kudoskitchenbyrenee.blogspot.com" rel="nofollow"><img alt="" src="http://1.gravatar.com/avatar/b0446734e43fe756f58f43d17a398e8a?s=66&amp;d=http%3A%2F%2Fwww.cookincanuck.com%2Fwp-content%2Fthemes%2Fthesis_18%2Fcustom%2Fimages%2Fcc_avatar.jpg%3Fs%3D66&amp;r=G" class="avatar avatar-66 photo" height="66" width="66" /></a></span>
+<span class="comment_num"><a href="#comment-216471" title="Permalink to this comment" rel="nofollow">27</a></span>
+<span class="comment_author"><a href="http://kudoskitchenbyrenee.blogspot.com" rel="external nofollow" class="url">Renee - Kudos Kitchen</a></span>
+<span class="comment_time">April 18, 2013 at 6:42 pm</span>
+
+					</dt>
+					<dd class="comment even thread-even depth-1">
+<div class="format_text" id="comment-body-216471">
+<p>I&#8217;ve just printed this recipe. It sounds like such a wonderfully flavorful light lunch or dinner.  Plus, I love that it has a little heat. Mmmmm. Thanks Dara.</p>
+<p class="reply"><a class="comment-reply-link" href="/2013/04/10-minute-thai-shrimp-cucumber-avocado-salad-recipe/?replytocom=216471#respond" onclick="return addComment.moveForm(&quot;comment-body-216471&quot;, &quot;216471&quot;, &quot;respond&quot;, &quot;9722&quot;)">Reply</a></p>
+</div>
+					</dd>
+				</dl><div id="respond">
+					<div id="respond_intro">
+<a rel="nofollow" id="cancel-comment-reply-link" href="/2013/04/10-minute-thai-shrimp-cucumber-avocado-salad-recipe/#respond" style="display:none;">Cancel reply</a>						<p>Leave a Comment</p>
+					</div>
+					<form action="http://www.cookincanuck.com/wp-comments-post.php" method="post" id="commentform">
+						<p><input class="text_input" type="text" name="author" id="author" value="" tabindex="1" aria-required="true" /><label for="author">Name <span class="required" title="Required">*</span></label></p>
+						<p><input class="text_input" type="text" name="email" id="email" value="" tabindex="2" aria-required="true" /><label for="email">E-mail <span class="required" title="Required">*</span></label></p>
+						<p><input class="text_input" type="text" name="url" id="url" value="" tabindex="3" /><label for="url">Website</label></p>
+						<p class="comment_box">
+							<textarea name="comment" id="comment" tabindex="4" cols="40" rows="8"></textarea></p>
+						<p class="remove_bottom_margin">
+							<input name="submit" class="form_submit" type="submit" id="submit" tabindex="5" value="Submit" /><input type="hidden" name="comment_post_ID" value="9722" id="comment_post_ID" /><input type="hidden" name="comment_parent" id="comment_parent" value="0" /></p>
+<p style="display: none;"><input type="hidden" id="akismet_comment_nonce" name="akismet_comment_nonce" value="1990fdf94f" /></p>					</form>
+				</div>
+				<div id="trackbacks_intro" class="comments_intro">
+					<p><span class="bracket">{</span> <span>1</span> trackback <span class="bracket">}</span></p>
+				</div>
+
+				<ul id="trackback_list"><li><a href="http://naomihattaway.com/2013/04/weekend-whimsy-20-21-april-2013/" rel="nofollow">Weekend Whimsy : 20-21 April 2013 | Box 53b</a></li>
+				</ul></div>
+					<div class="prev_next post_nav">
+						<p class="previous">Previous post: <a href="http://www.cookincanuck.com/2013/04/roasted-vegetable-pasta-salad-recipe-eggplant-zucchini-feta-cheese/" rel="prev">Roasted Vegetable Pasta Salad Recipe with Eggplant, Zucchini &amp; Feta Cheese</a></p>
+						<p>Next post: <a href="http://www.cookincanuck.com/2013/04/vegetable-stir-fry-recipe-endive-shiitake-mushrooms/" rel="next">Vegetable Stir-Fry Recipe with Endive &amp; Shiitake Mushrooms</a></p>
+					</div>
+		</div>
+
+		<div id="sidebars">
+			<div id="multimedia_box" class="custom_box">
+				<div id="custom_box">
+<table border="0" cellspacing="0" bordercolor="#000000" cellpadding="2" width="370" bgcolor="#ffffff"><tbody><tr><td valign="top"><img style="background-image: none; border-right-width: 0px; margin: 3px 10px 5px 0px; padding-left: 0px; padding-right: 0px; display: inline; float: left; border-top-width: 0px; border-bottom-width: 0px; border-left-width: 0px; padding-top: 0px" title="Dara of Cookin' Canuck" alt="Dara of Cookin' Canuck" src="http://www.cookincanuck.com/wp-content/uploads/2012/10/16.jpg" /><font color="#0000ff"> &#13;
+          <p><strong><font color="#000000">I'm Dara of Cookin' Canuck. Welcome to my kitchen. </font></strong></p>&#13;
+&#13;
+        </font>It's asparagus season!  Click <a href="http://www.cookincanuck.com/tag/asparagus/">here</a> for <a href="http://www.cookincanuck.com/tag/asparagus/">my favorite asparagus recipes</a>.&#13;
+        </td>&#13;
+    </tr><tr><td valign="top"> &#13;
+	  <a href="http://www.twitter.com/CookinCanuck" target="_blank"><img src="http://66.147.244.219/~cookinca/wp-content/themes/thesis_18/custom/images/twitter.png" /></a> &#13;
+	  <a href="https://www.facebook.com/pages/Cookin-Canuck/95009143389?ref=ts" target="_blank"><img src="http://66.147.244.219/~cookinca/wp-content/themes/thesis_18/custom/images/facebook.png" /></a> &#13;
+<a href="http://pinterest.com/cookincanuck" target="_blank"><img src="http://www.cookincanuck.com/wp-content/uploads/2012/01/big-p-button32.gif" /></a>&#13;
+	  <a href="http://www.stumbleupon.com/stumbler/cookincanuck/" target="_blank"><img src="http://66.147.244.219/~cookinca/wp-content/themes/thesis_18/custom/images/stumbleupon.png" /></a> &#13;
+<a href="https://plus.google.com/102466915374054302329/posts?rel=author" target="_blank"><img src="http://www.cookincanuck.com/wp-content/uploads/2012/05/new-g-plus-icon-32.png" /></a>&#13;
+<a href="http://instagram.com/cookincanuck" target="_blank"><img src="http://www.cookincanuck.com/wp-content/uploads/2013/01/instagram32.png" /></a>&#13;
+<a href="http://feeds.feedburner.com/blogspot/hIdj"><img src="http://66.147.244.219/~cookinca/wp-content/themes/thesis_18/custom/images/rss.png" /></a> &#13;
+</td>&#13;
+    </tr></tbody></table></div>
+			</div>
+			<div id="sidebar_1" class="sidebar">
+				<ul class="sidebar_list"><li class="widget thesis_widget_search" id="search">
+<h3>Search for Recipes</h3>
+<form method="get" class="search_form" action="http://www.cookincanuck.com/">
+	<p>
+		<input class="text_input" type="text" value="Search Cookin Canuck" name="s" id="s" onfocus="if (this.value == 'Search Cookin Canuck') {this.value = '';}" onblur="if (this.value == '') {this.value = 'Search Cookin Canuck';}" /><input type="hidden" id="searchsubmit" value="Search" /></p>
+</form>
+</li>
+<li class="widget widget_text" id="text-35"><h3>It helps to support this blog when you start your Amazon shopping here.  Thank you!</h3>			<div class="textwidget"><script charset="utf-8" type="text/javascript" src="http://ws.amazon.com/widgets/q?rt=tf_sw&amp;ServiceVersion=20070822&amp;MarketPlace=US&amp;ID=V20070822/US/coocan0f-20/8002/8395fc19-4fc9-43a1-b5b0-c1a189742de9"> </script><noscript><a href="http://ws.amazon.com/widgets/q?rt=tf_sw&amp;ServiceVersion=20070822&amp;MarketPlace=US&amp;ID=V20070822%2FUS%2Fcoocan0f-20%2F8002%2F8395fc19-4fc9-43a1-b5b0-c1a189742de9&amp;Operation=NoScript">Amazon.com Widgets</a></noscript></div>
+		</li><li class="widget widget_text" id="text-34">			<div class="textwidget"><a title="Follow Cookin Canuck on Bloglovin" href="http://www.bloglovin.com/en/blog/3888919"><img src="http://www.bloglovin.com/widget/bilder/en/widget.gif?id=3888919" alt="Follow on Bloglovin" border="0" /></a>.</div>
+		</li><li class="widget widget_text" id="text-3">			<div class="textwidget"><!-- BEGIN 160x600 MAIN AD-->
+<script src="http://ads.blogherads.com/63/6348/160a.js" type="text/javascript"></script><!-- END 160x600 MAIN AD--></div>
+		</li><li class="widget widget_text" id="text-14">			<div class="textwidget"><a href="http://www.cookincanuck.com/favorite-reads"><img src="http://www.cookincanuck.com/wp-content/uploads/2011/05/favreads_border.jpg" /></a></div>
+		</li><li class="widget widget_text" id="text-37">			<div class="textwidget"><img src=" http://www.cookincanuck.com/wp-content/uploads/2013/04/CAC-Blog-Ambassador-ad-v4-125x125.png" width="150" height="150" /></div>
+		</li><li class="widget widget_archive" id="archives-3"><h3>Archives</h3>		<select name="archive-dropdown" onchange="document.location.href=this.options[this.selectedIndex].value;"><option value="">Select Month</option><option value="http://www.cookincanuck.com/2013/04/"> April 2013 </option><option value="http://www.cookincanuck.com/2013/03/"> March 2013 </option><option value="http://www.cookincanuck.com/2013/02/"> February 2013 </option><option value="http://www.cookincanuck.com/2013/01/"> January 2013 </option><option value="http://www.cookincanuck.com/2012/12/"> December 2012 </option><option value="http://www.cookincanuck.com/2012/11/"> November 2012 </option><option value="http://www.cookincanuck.com/2012/10/"> October 2012 </option><option value="http://www.cookincanuck.com/2012/09/"> September 2012 </option><option value="http://www.cookincanuck.com/2012/08/"> August 2012 </option><option value="http://www.cookincanuck.com/2012/07/"> July 2012 </option><option value="http://www.cookincanuck.com/2012/06/"> June 2012 </option><option value="http://www.cookincanuck.com/2012/05/"> May 2012 </option><option value="http://www.cookincanuck.com/2012/04/"> April 2012 </option><option value="http://www.cookincanuck.com/2012/03/"> March 2012 </option><option value="http://www.cookincanuck.com/2012/02/"> February 2012 </option><option value="http://www.cookincanuck.com/2012/01/"> January 2012 </option><option value="http://www.cookincanuck.com/2011/12/"> December 2011 </option><option value="http://www.cookincanuck.com/2011/11/"> November 2011 </option><option value="http://www.cookincanuck.com/2011/10/"> October 2011 </option><option value="http://www.cookincanuck.com/2011/09/"> September 2011 </option><option value="http://www.cookincanuck.com/2011/08/"> August 2011 </option><option value="http://www.cookincanuck.com/2011/07/"> July 2011 </option><option value="http://www.cookincanuck.com/2011/06/"> June 2011 </option><option value="http://www.cookincanuck.com/2011/05/"> May 2011 </option><option value="http://www.cookincanuck.com/2011/04/"> April 2011 </option><option value="http://www.cookincanuck.com/2011/03/"> March 2011 </option><option value="http://www.cookincanuck.com/2011/02/"> February 2011 </option><option value="http://www.cookincanuck.com/2011/01/"> January 2011 </option><option value="http://www.cookincanuck.com/2010/12/"> December 2010 </option><option value="http://www.cookincanuck.com/2010/11/"> November 2010 </option><option value="http://www.cookincanuck.com/2010/10/"> October 2010 </option><option value="http://www.cookincanuck.com/2010/09/"> September 2010 </option><option value="http://www.cookincanuck.com/2010/08/"> August 2010 </option><option value="http://www.cookincanuck.com/2010/07/"> July 2010 </option><option value="http://www.cookincanuck.com/2010/06/"> June 2010 </option><option value="http://www.cookincanuck.com/2010/05/"> May 2010 </option><option value="http://www.cookincanuck.com/2010/04/"> April 2010 </option><option value="http://www.cookincanuck.com/2010/03/"> March 2010 </option><option value="http://www.cookincanuck.com/2010/02/"> February 2010 </option><option value="http://www.cookincanuck.com/2010/01/"> January 2010 </option><option value="http://www.cookincanuck.com/2009/12/"> December 2009 </option><option value="http://www.cookincanuck.com/2009/11/"> November 2009 </option><option value="http://www.cookincanuck.com/2009/10/"> October 2009 </option><option value="http://www.cookincanuck.com/2009/09/"> September 2009 </option><option value="http://www.cookincanuck.com/2009/08/"> August 2009 </option><option value="http://www.cookincanuck.com/2009/07/"> July 2009 </option><option value="http://www.cookincanuck.com/2009/06/"> June 2009 </option><option value="http://www.cookincanuck.com/2009/05/"> May 2009 </option><option value="http://www.cookincanuck.com/2009/04/"> April 2009 </option></select></li><li class="widget widget_text" id="text-13">			<div class="textwidget"><!-- Start: GPT Sync -->&#13;
+<script type="text/javascript">&#13;
+(function(){&#13;
+var useSSL = 'https:' == document.location.protocol;&#13;
+var src = (useSSL ? 'https:' : 'http:') + '//www.googletagservices.com/tag/js/gpt.js';&#13;
+document.write('&lt;scr' + 'ipt src="' + src + '"&gt;&lt;/scr' + 'ipt&gt;');&#13;
+})();&#13;
+</script><script type="text/javascript">&#13;
+ &#13;
+//Adslot 1 declaration&#13;
+var slot1= googletag.defineSlot('/15704463/Cookin_Canuck/non-homepage/btf_rt', [[160,600]],'div-gpt-ad-584089601286837009-1').addService(googletag.pubads());&#13;
+ &#13;
+googletag.pubads().enableSyncRendering();&#13;
+googletag.enableServices();&#13;
+ &#13;
+</script><!-- End: GPT --><!-- Beginning Sync AdSlot 1 for Ad unit Cookin_Canuck/non-homepage/btf_rt ### size: [[160,600]]  --><div id="div-gpt-ad-584089601286837009-1">&#13;
+<script type="text/javascript">&#13;
+googletag.display('div-gpt-ad-584089601286837009-1');&#13;
+</script></div>&#13;
+<!-- End AdSlot 1 --></div>
+		</li><li class="widget widget_text" id="text-11">			<div class="textwidget"><a href="http://www.babble.com/best-recipes/top-100-food-mom-blog-2013/"><img src="http://www.babble.com/wp-content/uploads/2013/03/image.png" width="150" height="150" /></a></div>
+		</li><li class="widget widget_text" id="text-20">			<div class="textwidget"><a href="http://www.flickr.com/photos/cookincanuck/6797424051/" title="Print by CookinCanuck, on Flickr"><img src="http://farm8.staticflickr.com/7028/6797424051_1cc37031b4_t.jpg" width="140" height="140" alt="Print" /></a>
+</div>
+		</li><li class="widget widget_text" id="text-28"><h3>I also write here:</h3>			<div class="textwidget"><p style="text-align:center;"><a href="http://www.allparenting.com/authors/dara-michalski"><img border="0" src="http://www.cookincanuck.com/wp-content/uploads/2012/10/badge-writer.jpg" /></a></p></div>
+		</li><li class="widget widget_text" id="text-32">			<div class="textwidget"><div style="width: 140px !important; height: 170px !important; background:white !important; border: 1px solid #4D0A0B !important; overflow: hidden !important; text-align: center !important;"><a href="http://foodblogsearch.com" target="_blank">&#13;
+    <img src="http://foodblogsearch.com/images/fbs-button-140.png" style="border:0 !important; padding:0 !important; margin-bottom:5px !important;" /></a>&#13;
+    <!-- Google CSE Search Box Begins  -->&#13;
+    <form action="http://foodblogsearch.com/results/" id="searchbox_003084314295129404805:72ozi9a0fjk" style="margin:0 !important; padding:0 !important;">&#13;
+    <input type="hidden" name="cx" value="003084314295129404805:72ozi9a0fjk" /><input type="hidden" name="cof" value="FORID:11" /><input type="text" name="q" style="border:solid 1px #8A7C7D !important; width:128px !important; height:16px !important; " /><input type="image" src="http://www.foodblogsearch.com/images/search-fb-button-2.png" value="Search Food Blogs" alt="Search Food Blogs" name="sa" title="Search Food Blogs" id="search-button" style="margin-top:4px !important;" /></form>&#13;
+    <script type="text/javascript" src="http://www.google.com/coop/cse/brand?form=searchbox_003084314295129404805%3A72ozi9a0fjk"></script><!-- Google CSE Search Box Ends --></div></div>
+		</li><li class="widget widget_text" id="text-4">			<div class="textwidget"><script type="text/javascript" src="http://www.googletagservices.com/tag/js/gpt.js">var pb_ord = Math.floor(Math.random()*10000000000000001);googletag.defineSlot('/15704463/Cookin_Canuck/non-homepage/btf_rt',[[160,600]],'div-non-homepage-btf_rt' + pb_ord ).addService(googletag.pubads());googletag.pubads().enableSyncRendering();googletag.enableServices();googletag.display('div-non-homepage-btf_rt' + pb_ord);</script></div>
+		</li><li class="widget widget_text" id="text-36">			<div class="textwidget"><a style="border: none;" href="http://cookeatshare.com/"><img style="border: none; width: 110px; height: 48px; vertical-align: bottom; padding: 0; margin: 0;" title="CookEatShare Featured Author" src="http://cookeatshare.com/images/fa_badge/top.png" alt="CookEatShare Featured Author" /></a>&#13;
+<div style="font-family: Arial,sans-serif; font-size: 12px; font-weight: bold; color: #ffd553 !important; width: 100px; text-align: center; background-color: #a0be29 !important; padding: 5px;">view my <a style="font-family: Arial,sans-serif; font-size: 12px; font-weight: bold; color: #ffd553 !important; text-decoration: underline;" href="http://cookeatshare.com/chefs/cookin-canuck-41043/recipes">recipes</a></div>&#13;
+<img style="border: none; width: 110px; height: 4px; padding: 0; margin: 0; vertical-align: top;" title="CookEatShare Featured Author" src="http://cookeatshare.com/images/fa_badge/bottom.png" alt="CookEatShare Featured Author" /></div>
+		</li>				</ul></div>
+			<div id="sidebar_2" class="sidebar">
+				<ul class="sidebar_list"><li class="widget widget_text" id="text-27"><h3>Receive Email Updates</h3>			<div class="textwidget"><form style="border:1px solid #ccc;padding:3px;text-align:center;" action="http://feedburner.google.com/fb/a/mailverify" method="post" target="popupwindow" onsubmit="window.open('http://feedburner.google.com/fb/a/mailverify?uri=CookinCanuck', 'popupwindow', 'scrollbars=yes,width=550,height=520');return true"><p>Enter your email address:</p><p><input type="text" style="width:140px" name="email" /></p><input type="hidden" value="CookinCanuck" name="uri" /><input type="hidden" name="loc" value="en_US" /><input type="submit" value="Subscribe" /></form></div>
+		</li><li class="widget widget_text" id="text-26"><h3>Cookin&#8217; Canuck&#8217;s Weight Loss Journey (Click on the photo)</h3>			<div class="textwidget"><a href="http://www.cookincanuck.com/2012/02/my-health-and-weight-loss-journey-before-and-after-photos/"><img src="http://www.cookincanuck.com/wp-content/uploads/2012/03/Dara-after-150x250.jpg" alt="" title="Dara-after" width="150" height="250" class="aligncenter size-thumbnail wp-image-5127" /></a></div>
+		</li><!-- Wordpress Popular Posts Plugin v2.3.2 [W] [weekly] [regular] -->
+<li class="widget popular-posts" id="wpp-2">
+<h3>Popular Posts</h3><!-- Wordpress Popular Posts Plugin v2.3.2 [Widget] [weekly] [regular] -->
+<ul><li><a href="http://www.cookincanuck.com/2013/04/the-boston-marathon-grieving-and-looking-ahead/" class="wpp-thumbnail" title="A Personal Account &#8211; The Boston Marathon: Grieving&#8230;And Looking Ahead"><img src="http://www.cookincanuck.com/wp-content/plugins/wordpress-popular-posts/timthumb.php?src=http://www.cookincanuck.com/wp-content/uploads/2013/04/BostonSquare.jpg&amp;h=165&amp;w=165" width="165" height="165" alt="A Personal Account &#8211; The Boston Marathon: Grieving&#8230;And Looking Ahead" border="0" class="wpp-thumbnail wpp_fi" /></a><a href="http://www.cookincanuck.com/2013/04/the-boston-marathon-grieving-and-looking-ahead/" title="A Personal Account &#8211; The Boston Marathon: Grieving&#8230;And Looking Ahead" class="wpp-post-title">A Personal Account &#8211; The Boston Marathon: Grieving&#8230;And Looking Ahead</a> <span class="post-stats"></span></li>
+<li><a href="http://www.cookincanuck.com/2013/04/low-fat-chicken-salad-recipe-curry-apricots/" class="wpp-thumbnail" title="Low-Fat Chicken Salad Recipe with Curry &amp; Apricots"><img src="http://www.cookincanuck.com/wp-content/plugins/wordpress-popular-posts/timthumb.php?src=http://www.cookincanuck.com/wp-content/uploads/2013/04/ChickenSaladSquare.jpg&amp;h=165&amp;w=165" width="165" height="165" alt="Low-Fat Chicken Salad Recipe with Curry &amp; Apricots" border="0" class="wpp-thumbnail wpp_fi" /></a><a href="http://www.cookincanuck.com/2013/04/low-fat-chicken-salad-recipe-curry-apricots/" title="Low-Fat Chicken Salad Recipe with Curry &amp; Apricots" class="wpp-post-title">Low-Fat Chicken Salad Recipe with Curry &amp; Apricots</a> <span class="post-stats"></span></li>
+<li><a href="http://www.cookincanuck.com/2013/04/vegetable-stir-fry-recipe-endive-shiitake-mushrooms/" class="wpp-thumbnail" title="Vegetable Stir-Fry Recipe with Endive &amp; Shiitake Mushrooms"><img src="http://www.cookincanuck.com/wp-content/plugins/wordpress-popular-posts/timthumb.php?src=http://www.cookincanuck.com/wp-content/uploads/2013/04/MushroomEndiveSquare.jpg&amp;h=165&amp;w=165" width="165" height="165" alt="Vegetable Stir-Fry Recipe with Endive &amp; Shiitake Mushrooms" border="0" class="wpp-thumbnail wpp_fi" /></a><a href="http://www.cookincanuck.com/2013/04/vegetable-stir-fry-recipe-endive-shiitake-mushrooms/" title="Vegetable Stir-Fry Recipe with Endive &amp; Shiitake Mushrooms" class="wpp-post-title">Vegetable Stir-Fry Recipe with Endive &amp; Shiitake Mushrooms</a> <span class="post-stats"></span></li>
+<li><a href="http://www.cookincanuck.com/2013/04/10-minute-thai-shrimp-cucumber-avocado-salad-recipe/" class="wpp-thumbnail" title="10-Minute Thai Shrimp, Cucumber &amp; Avocado Salad Recipe"><img src="http://www.cookincanuck.com/wp-content/plugins/wordpress-popular-posts/timthumb.php?src=http://www.cookincanuck.com/wp-content/uploads/2013/04/Thai-Shrimp-Cucumber.jpg&amp;h=165&amp;w=165" width="165" height="165" alt="10-Minute Thai Shrimp, Cucumber &amp; Avocado Salad Recipe" border="0" class="wpp-thumbnail wpp_fi" /></a><a href="http://www.cookincanuck.com/2013/04/10-minute-thai-shrimp-cucumber-avocado-salad-recipe/" title="10-Minute Thai Shrimp, Cucumber &amp; Avocado Salad Recipe" class="wpp-post-title">10-Minute Thai Shrimp, Cucumber &amp; Avocado Salad Recipe</a> <span class="post-stats"></span></li>
+<li><a href="http://www.cookincanuck.com/2011/11/hearty-chicken-stew-with-butternut-squash-quinoa-recipe/" class="wpp-thumbnail" title="Hearty Chicken Stew with Butternut Squash &amp; Quinoa Recipe"><img src="http://www.cookincanuck.com/wp-content/plugins/wordpress-popular-posts/timthumb.php?src=http://www.cookincanuck.com/wp-content/uploads/2013/04/ButternutQuinoaStewSquareSmall.jpg&amp;h=165&amp;w=165" width="165" height="165" alt="Hearty Chicken Stew with Butternut Squash &amp; Quinoa Recipe" border="0" class="wpp-thumbnail wpp_fi" /></a><a href="http://www.cookincanuck.com/2011/11/hearty-chicken-stew-with-butternut-squash-quinoa-recipe/" title="Hearty Chicken Stew with Butternut Squash &amp; Quinoa Recipe" class="wpp-post-title">Hearty Chicken Stew with Butternut Squash &amp; Quinoa Recipe</a> <span class="post-stats"></span></li>
+<li><a href="http://www.cookincanuck.com/contact/" class="wpp-thumbnail" title="Contact"><img src="http://www.cookincanuck.com/wp-content/plugins/wordpress-popular-posts/timthumb.php?src=http://www.cookincanuck.com/wp-content/uploads/2013/04/Dara-FinalSquare.jpg&amp;h=165&amp;w=165" width="165" height="165" alt="Contact" border="0" class="wpp-thumbnail wpp_fi" /></a><a href="http://www.cookincanuck.com/contact/" title="Contact" class="wpp-post-title">Contact</a> <span class="post-stats"></span></li>
+<li><a href="http://www.cookincanuck.com/2013/01/baked-turkey-quinoa-zucchini-meatballs-recipe-in-lettuce-wraps/" class="wpp-thumbnail" title="Baked Turkey, Quinoa &amp; Zucchini Meatballs Recipe in Lettuce Wraps"><img src="http://www.cookincanuck.com/wp-content/plugins/wordpress-popular-posts/timthumb.php?src=http://www.cookincanuck.com/wp-content/uploads/2013/03/MeatballLettuceWrapsSquare.jpg&amp;h=165&amp;w=165" width="165" height="165" alt="Baked Turkey, Quinoa &amp; Zucchini Meatballs Recipe in Lettuce Wraps" border="0" class="wpp-thumbnail wpp_fi" /></a><a href="http://www.cookincanuck.com/2013/01/baked-turkey-quinoa-zucchini-meatballs-recipe-in-lettuce-wraps/" title="Baked Turkey, Quinoa &amp; Zucchini Meatballs Recipe in Lettuce Wraps" class="wpp-post-title">Baked Turkey, Quinoa &amp; Zucchini Meatballs Recipe in Lettuce Wraps</a> <span class="post-stats"></span></li>
+<li><a href="http://www.cookincanuck.com/2013/03/baked-tilapia-recipe-with-pecan-rosemary-topping/" class="wpp-thumbnail" title="Baked Tilapia Recipe with Pecan Rosemary Topping"><img src="http://www.cookincanuck.com/wp-content/plugins/wordpress-popular-posts/timthumb.php?src=http://www.cookincanuck.com/wp-content/uploads/2013/03/TilapiaPecanRosemarySquare.jpg&amp;h=165&amp;w=165" width="165" height="165" alt="Baked Tilapia Recipe with Pecan Rosemary Topping" border="0" class="wpp-thumbnail wpp_fi" /></a><a href="http://www.cookincanuck.com/2013/03/baked-tilapia-recipe-with-pecan-rosemary-topping/" title="Baked Tilapia Recipe with Pecan Rosemary Topping" class="wpp-post-title">Baked Tilapia Recipe with Pecan Rosemary Topping</a> <span class="post-stats"></span></li>
+<li><a href="http://www.cookincanuck.com/2012/04/whole-wheat-pasta-salad-recipe-with-salmon-tomatoes-herb-dressing-for-a-half-marathon/" class="wpp-thumbnail" title="Whole Wheat Pasta Salad Recipe with Salmon, Tomatoes &amp; Herb Dressing for a Half-Marathon"><img src="http://www.cookincanuck.com/wp-content/plugins/wordpress-popular-posts/timthumb.php?src=http://www.cookincanuck.com/wp-content/uploads/2013/04/6938946520_1a106c7a20-2.jpg&amp;h=165&amp;w=165" width="165" height="165" alt="Whole Wheat Pasta Salad Recipe with Salmon, Tomatoes &amp; Herb Dressing for a Half-Marathon" border="0" class="wpp-thumbnail wpp_fi" /></a><a href="http://www.cookincanuck.com/2012/04/whole-wheat-pasta-salad-recipe-with-salmon-tomatoes-herb-dressing-for-a-half-marathon/" title="Whole Wheat Pasta Salad Recipe with Salmon, Tomatoes &amp; Herb Dressing for a Half-Marathon" class="wpp-post-title">Whole Wheat Pasta Salad Recipe with Salmon, Tomatoes &amp; Herb Dressing for a Half-Marathon</a> <span class="post-stats"></span></li>
+<li><a href="http://www.cookincanuck.com/2011/10/spaghetti-squash-with-apples-toasted-pecans-recipe/" class="wpp-thumbnail" title="Spaghetti Squash with Apples &amp; Toasted Pecans Recipe"><img src="http://www.cookincanuck.com/wp-content/plugins/wordpress-popular-posts/timthumb.php?src=http://www.cookincanuck.com/wp-content/uploads/2013/04/SpagSquashAppleSquareSmall.jpg&amp;h=165&amp;w=165" width="165" height="165" alt="Spaghetti Squash with Apples &amp; Toasted Pecans Recipe" border="0" class="wpp-thumbnail wpp_fi" /></a><a href="http://www.cookincanuck.com/2011/10/spaghetti-squash-with-apples-toasted-pecans-recipe/" title="Spaghetti Squash with Apples &amp; Toasted Pecans Recipe" class="wpp-post-title">Spaghetti Squash with Apples &amp; Toasted Pecans Recipe</a> <span class="post-stats"></span></li>
+
+</ul></li>
+<!-- End Wordpress Popular Posts Plugin v2.3.2 -->
+<li class="widget widget_text" id="text-12">			<div class="textwidget"><!-- Start: GPT Sync -->&#13;
+<script type="text/javascript">&#13;
+(function(){&#13;
+var useSSL = 'https:' == document.location.protocol;&#13;
+var src = (useSSL ? 'https:' : 'http:') + '//www.googletagservices.com/tag/js/gpt.js';&#13;
+document.write('&lt;scr' + 'ipt src="' + src + '"&gt;&lt;/scr' + 'ipt&gt;');&#13;
+})();&#13;
+</script><script type="text/javascript">&#13;
+ &#13;
+//Adslot 1 declaration&#13;
+var slot1= googletag.defineSlot('/15704463/Cookin_Canuck/non-homepage/atf_rt', [[160,600]],'div-gpt-ad-566689520317929284-1').addService(googletag.pubads());&#13;
+ &#13;
+googletag.pubads().enableSyncRendering();&#13;
+googletag.enableServices();&#13;
+ &#13;
+</script><!-- End: GPT --><!-- Beginning Sync AdSlot 1 for Ad unit Cookin_Canuck/non-homepage/atf_rt ### size: [[160,600]]  --><div id="div-gpt-ad-566689520317929284-1">&#13;
+<script type="text/javascript">&#13;
+googletag.display('div-gpt-ad-566689520317929284-1');&#13;
+</script></div>&#13;
+<!-- End AdSlot 1 --></div>
+		</li>				</ul></div>
+		</div>
+	</div>
+	<div id="footer">
+	<div id="footer_setup">&#13;
+&#13;
+		<div class="footer_items">&#13;
+  	  					<div class="textwidget"><!-- Start: GPT Sync -->&#13;
+<script type="text/javascript">&#13;
+(function(){&#13;
+var useSSL = 'https:' == document.location.protocol;&#13;
+var src = (useSSL ? 'https:' : 'http:') + '//www.googletagservices.com/tag/js/gpt.js';&#13;
+document.write('&lt;scr' + 'ipt src="' + src + '"&gt;&lt;/scr' + 'ipt&gt;');&#13;
+})();&#13;
+</script><script type="text/javascript">&#13;
+ &#13;
+//Adslot 1 declaration&#13;
+var slot1= googletag.defineSlot('/15704463/Cookin_Canuck/non-homepage/btf_ct', [[728,90]],'div-gpt-ad-952071100438817033-1').addService(googletag.pubads());&#13;
+ &#13;
+googletag.pubads().enableSyncRendering();&#13;
+googletag.enableServices();&#13;
+ &#13;
+</script><!-- End: GPT --><!-- Beginning Sync AdSlot 1 for Ad unit Cookin_Canuck/non-homepage/btf_ct ### size: [[728,90]]  --><div id="div-gpt-ad-952071100438817033-1">&#13;
+<script type="text/javascript">&#13;
+googletag.display('div-gpt-ad-952071100438817033-1');&#13;
+</script></div>&#13;
+<!-- End AdSlot 1 --></div>
+				</div>&#13;
+&#13;
+		<div class="footer_items">&#13;
+    					<div class="textwidget"><!-- Start: GPT Sync -->&#13;
+<script type="text/javascript">&#13;
+(function(){&#13;
+var useSSL = 'https:' == document.location.protocol;&#13;
+var src = (useSSL ? 'https:' : 'http:') + '//www.googletagservices.com/tag/js/gpt.js';&#13;
+document.write('&lt;scr' + 'ipt src="' + src + '"&gt;&lt;/scr' + 'ipt&gt;');&#13;
+})();&#13;
+</script><script type="text/javascript">&#13;
+ &#13;
+//Adslot 1 declaration&#13;
+var slot1= googletag.defineSlot('/15704463/Cookin_Canuck/non-homepage/btf_ct', [[728,90]],'div-gpt-ad-952071100438817033-1').addService(googletag.pubads());&#13;
+ &#13;
+googletag.pubads().enableSyncRendering();&#13;
+googletag.enableServices();&#13;
+ &#13;
+</script><!-- End: GPT --><!-- Beginning Sync AdSlot 1 for Ad unit Cookin_Canuck/non-homepage/btf_ct ### size: [[728,90]]  --><div id="div-gpt-ad-952071100438817033-1">&#13;
+<script type="text/javascript">&#13;
+googletag.display('div-gpt-ad-952071100438817033-1');&#13;
+</script></div>&#13;
+<!-- End AdSlot 1 --></div>
+				</div>&#13;
+&#13;
+		<div class="footer_items">&#13;
+    		    				</div>&#13;
+&#13;
+	</div>&#13;
+<p>CookinCanuck Copyright &#169;2013</p><script type="text/javascript">var SHRSB_Settings = {"shr-publisher-9722":{"link":"http:\/\/www.cookincanuck.com\/2013\/04\/10-minute-thai-shrimp-cucumber-avocado-salad-recipe\/","shortener":"google","title":"10-Minute Thai Shrimp, Cucumber &amp; Avocado Salad Recipe ","notes":"%0D%0A%0D%0A%22Quick%20lunch%22%20does%20not%20have%20to%20mean%20%22boring%20lunch%22.%20Believe%20me%2C%20I%27ve%20had%20my%20fair%20share%20of%20lackluster%20sandwiches%20or%20past-their-prime%20leftovers%2C%20but%20leaving%20the%20table%20dissatisfied%20leads%20to%20trouble.%20Snacking%20kind%20of%20trouble.%20And%20I%20don%27t%20mean%20the%20good%20kind%20of%20snacking.%20A%20couple%20of%20cheese%20and%20cracker","service":"309,5,7,304,38,191","apikey":"8afa39428933be41f8afdb8ea21a495c","expand":true,"src":"http:\/\/www.cookincanuck.com\/wp-content\/uploads\/shareaholic\/spritegen","localize":true,"share_src":"http:\/\/www.shareaholic.com","rel":"nofollow","target":"_blank","bgimg":"http:\/\/www.cookincanuck.com\/wp-content\/plugins\/shareaholic\/images\/share-love-hearts.png","bgimg_padding":"26px 0 0 10px","twitter_template":"%24%7Btitle%7D+-+%24%7Bshort_link%7D+via+%40cookincanuck","mode":"inject","designer_toolTips":"1","tip_bg_color":"#000000","tip_text_color":"#ffffff"}};</script><script type="text/javascript" src="http://www.cookincanuck.com/wp-content/plugins/pinterest-pin-it-button/js/pin-it-button-user-selects-image.js?ver=3.3.2"></script><script type="text/javascript" src="http://www.cookincanuck.com/wp-content/plugins/pinterest-pin-it-button/js/pin-it-button-custom-btn-img.js?ver=3.3.2"></script></div>
+</div>
+</div>
+<!--[if lte IE 8]>
+<div id="ie_clear"></div>
+<![endif]-->
+<script type="text/javascript">&#13;
+&#13;
+  var _gaq = _gaq || [];&#13;
+  _gaq.push(['_setAccount', 'UA-8240651-1']);&#13;
+  _gaq.push(['_trackPageview']);&#13;
+&#13;
+  (function() {&#13;
+    var ga = document.createElement('script'); ga.type = 'text/javascript'; ga.async = true;&#13;
+    ga.src = ('https:' == document.location.protocol ? 'https://ssl' : 'http://www') + '.google-analytics.com/ga.js';&#13;
+    var s = document.getElementsByTagName('script')[0]; s.parentNode.insertBefore(ga, s);&#13;
+  })();&#13;
+&#13;
+</script></body>
+</html>

--- a/scrapy_proj/tests/scraper_tests.py
+++ b/scrapy_proj/tests/scraper_tests.py
@@ -73,10 +73,13 @@ def create_item_t(item):
     def do_test_scraped_item(self):
         msg = "Name is not in item %s" % (item)
         self.assertIn('name', item, msg)
+        self.assertNotEqual(item['name'], '', msg)
         msg = "Ingredients is not in item %s" % (item)
         self.assertIn('ingredients', item, msg)
+        self.assertNotEqual(item['ingredients'], '', msg)
         msg = "URL is not in item %s" % (item)
         self.assertIn('url', item, msg)
+        self.assertNotEqual(item['url'], '', msg)
     return do_test_scraped_item
 
 


### PR DESCRIPTION
This provides a simple script for grabbing html pages for static testing, fixes some tests that were illegitimately passing, moves the strip_html to the front of the ingredients item loader (so it runs on each ingredient, thereby fixing the filter_ingredients issue), and cleans up the cookincanuck spider so it's not sending html into the recipeitem in the first place.
